### PR TITLE
Use generators in `process_assigned_reads`

### DIFF
--- a/src/dataset_processor.py
+++ b/src/dataset_processor.py
@@ -386,7 +386,7 @@ class DatasetProcessor:
 
         self.multimapped_reads = {
             read_id: assignment_list
-            for read_id, assignment_list in self.merge_assignments.items()
+            for read_id, assignment_list in self.multimapped_reads.items()
             if len(assignment_list) > 1
         }
 


### PR DESCRIPTION
This PR was my first attempt at some memory optimization in the `process_assigned_reads` method, where I was having issues. Running it now, it doesn't fully solve the issues I'm having but I think it makes a small difference–still using a lot of memory but haven't run out so far.

Basically all I did here was re-arrange the code a bit to avoid needing to process everything at once. Among other things, line 392 (`read_stat_counters, transcript_stat_counters = zip(*results)`) was trying to unzip the entire results iterable, which required it all to be calculated before any processing could continue.

With this PR, each result is processed and can then be discarded (up to however many get backed up by the pool). I don't know how big these objects are but it seems to be lowering my memory usage at the moment.