### PR TITLE
Optimize read alignment collection 

### DIFF
--- a/isoquant.py
+++ b/isoquant.py
@@ -355,8 +355,14 @@ def set_logger(args, logger_instance):
 
     logger_instance.setLevel(output_level)
     log_file = os.path.join(args.output, "isoquant.log")
-    file_mode = "a" if args.resume else "w"
-    f = open(log_file, file_mode)
+    if os.path.exists(log_file):
+        old_log_file = os.path.join(args.output, "isoquant.log.old")
+        with open(old_log_file, "a") as olf:
+            olf.write("\n")
+            for l in open(log_file, "r"):
+                olf.write(l)
+
+    f = open(log_file, "w")
     f.write("Command line: " + args._cmd_line + '\n')
     f.close()
     fh = logging.FileHandler(log_file)

--- a/src/alignment_processor.py
+++ b/src/alignment_processor.py
@@ -409,6 +409,9 @@ class IntergenicAlignmentCollector:
         assert self.genedb is not None
         gene_list = list(self.genedb.region(seqid=self.chr_id, start=current_region[0],
                                             end=current_region[1], featuretype="gene"))
+        if not gene_list:
+            return GeneInfo.from_region(self.chr_id, current_region[0], current_region[1],
+                                        self.params.delta, self.chr_record)
         gene_list = sorted(gene_list, key=lambda x: x.start)
         gene_info = GeneInfo(gene_list, self.genedb, self.params.delta)
         if self.params.needs_reference:

--- a/src/alignment_processor.py
+++ b/src/alignment_processor.py
@@ -65,7 +65,7 @@ class BAMOnlineMerger:
 
 
 class AbstractAlignmentStorage:
-    COVERAGE_BIN = 256
+    COVERAGE_BIN = 512
 
     def __init__(self):
         self.coverage_dict = defaultdict(int)
@@ -189,7 +189,7 @@ class IntergenicAlignmentCollector:
     counter
     """
 
-    MAX_REGION_LEN = 32768
+    MAX_REGION_LEN = 65536
     MIN_READS_TO_SPLIT = 16384
     MIN_INTRONS_TO_SPLIT = 128
     ABS_COV_VALLEY = 1
@@ -416,9 +416,9 @@ class IntergenicAlignmentCollector:
         return gene_info
 
     def split_region(self, genomic_region, alignment_storage, gene_info):
-        if interval_len(genomic_region) <= IntergenicAlignmentCollector.MAX_REGION_LEN: # or \
-                #alignment_storage.get_read_count() <= IntergenicAlignmentCollector.MIN_READS_TO_SPLIT or \
-                #len(gene_info.intron_profiles.features) <= IntergenicAlignmentCollector.MIN_INTRONS_TO_SPLIT:
+        if interval_len(genomic_region) <= IntergenicAlignmentCollector.MAX_REGION_LEN or \
+                alignment_storage.get_read_count() <= IntergenicAlignmentCollector.MIN_READS_TO_SPLIT or \
+                len(gene_info.intron_profiles.features) <= IntergenicAlignmentCollector.MIN_INTRONS_TO_SPLIT:
             return [genomic_region]
 
         split_regions = []

--- a/src/alignment_processor.py
+++ b/src/alignment_processor.py
@@ -443,12 +443,13 @@ class IntergenicAlignmentCollector:
 
         split_regions = []
         coverage_positions = sorted(alignment_storage.coverage_dict.keys())
+        min_bins = int(self.MAX_REGION_LEN / AbstractAlignmentStorage.COVERAGE_BIN)
         current_start = coverage_positions[0]
         pos = current_start + 1
         max_cov = alignment_storage.coverage_dict[current_start]
 
         while pos <= coverage_positions[-1]:
-            while pos <= coverage_positions[-1] and \
+            while (pos <= coverage_positions[-1] and pos - current_start < min_bins) or \
                     alignment_storage.coverage_dict[pos] > max(self.ABS_COV_VALLEY, max_cov * self.REL_COV_VALLEY):
                 max_cov = max(max_cov, alignment_storage.coverage_dict[pos])
                 pos += 1

--- a/src/alignment_processor.py
+++ b/src/alignment_processor.py
@@ -247,7 +247,11 @@ class IntergenicAlignmentCollector:
         new_regions = self.split_region(current_region, alignment_storage, gene_info)
         for new_region in new_regions:
             new_gene_info = self.get_gene_info_for_region(new_region)
-            for assignment in self.process_genic(alignment_storage.get_alignments(new_region), new_gene_info):
+            if new_gene_info.gene_db_list:
+                assignment_iterator = self.process_genic(alignment_storage.get_alignments(new_region), new_gene_info)
+            else:
+                assignment_iterator = self.process_intergenic(alignment_storage.get_alignments(current_region))
+            for assignment in assignment_iterator:
                 yield assignment
 
     def process_intergenic(self, alignment_storage):

--- a/src/alignment_processor.py
+++ b/src/alignment_processor.py
@@ -74,7 +74,7 @@ class AbstractAlignmentStorage:
 
     def reset(self):
         self.coverage_dict = defaultdict(int)
-        self.current_bin_region_start = math.inf
+        self.current_bin_region_start = 4294967296 # infinity
         self.current_bin_region_end = 0
 
     def add_alignment(self, bam_index, alignment):

--- a/src/alignment_processor.py
+++ b/src/alignment_processor.py
@@ -34,6 +34,7 @@ class BAMOnlineMerger:
         self._set(chr_id, start, end)
 
     def _set(self, chr_id, start, end):
+        assert end >= start
         self.chr_id = chr_id
         self.start = start
         self.end = end
@@ -161,6 +162,7 @@ class InMemoryAlignmentStorage(AbstractAlignmentStorage):
                 current_index = self.alignment_end_index[pos]
 
     def get_alignments(self, region):
+        assert region[1] >= region[0]
         self._fill_index()
         # first alignment among sorted that has its end inside the start_bin, e.g. close to region[0]
         start_bin = region[0] // self.COVERAGE_BIN
@@ -224,7 +226,7 @@ class IntergenicAlignmentCollector:
             else:
                 yield self.process_alignments_in_region(current_region, alignment_storage)
                 alignment_storage.reset()
-                current_region = None
+                current_region = (alignment.reference_start, alignment.reference_end)
 
             alignment_storage.add_alignment(bam_index, alignment)
 

--- a/src/dataset_processor.py
+++ b/src/dataset_processor.py
@@ -57,7 +57,7 @@ def collect_reads_in_parallel(sample, chr_id, args, read_grouper, current_chr_re
                 read_grouper.read_groups.add(g.strip())
             for gene_info, assignment_storage in load_assigned_reads(save_file, None, None):
                 for a in assignment_storage:
-                    processed_reads.append(BasicReadAssignment(a, gene_info))
+                    processed_reads.append(BasicReadAssignment(a))
             logger.info("Loaded data for " + chr_id)
             return processed_reads, read_grouper.read_groups
         else:
@@ -76,7 +76,7 @@ def collect_reads_in_parallel(sample, chr_id, args, read_grouper, current_chr_re
         tmp_printer.add_gene_info(gene_info)
         for read_assignment in assignment_storage:
             tmp_printer.add_read_info(read_assignment)
-            processed_reads.append(BasicReadAssignment(read_assignment, gene_info))
+            processed_reads.append(BasicReadAssignment(read_assignment))
     with open(group_file, "w") as group_dump:
         for g in read_grouper.read_groups:
             group_dump.write("%s\n" % g)
@@ -118,13 +118,9 @@ def load_assigned_reads(save_file_name, gffutils_db, multimapped_chr_dict):
                 if multimapped_chr_dict is not None and read_assignment.read_id in multimapped_chr_dict:
                     resolved_assignment = None
                     for a in multimapped_chr_dict[read_assignment.read_id]:
-                        if a.start == read_assignment.start() and a.end == read_assignment.end() and \
-                                a.chr_id == read_assignment.chr_id and \
-                                (a.assignment_type in [ReadAssignmentType.intergenic, ReadAssignmentType.noninformative] or
-                                 ((not current_gene_info.gene_db_list or a.gene_id == current_gene_info.gene_db_list[0].id) and
-                                  a.matches == (0 if not read_assignment.isoform_matches else len(read_assignment.isoform_matches)))):
+                        if a.assignment_id == read_assignment.assignment_id and a.chr_id == read_assignment.chr_id:
                             if resolved_assignment is not None:
-                                logger.debug("Duplicate read: %s %s %s" % (read_assignment.read_id, a.gene_id, a.chr_id))
+                                logger.info("Duplicate read: %s %s %s" % (read_assignment.read_id, a.gene_id, a.chr_id))
                             resolved_assignment = a
 
                     if not resolved_assignment:

--- a/src/dataset_processor.py
+++ b/src/dataset_processor.py
@@ -459,10 +459,12 @@ class DatasetProcessor:
 
     def create_aggregators(self, sample):
         self.read_stat_counter = EnumStats()
-        self.basic_printer = BasicTSVAssignmentPrinter(sample.out_assigned_tsv, self.args, self.io_support,
-                                                       additional_header=self.common_header)
         self.corrected_bed_printer = BEDPrinter(sample.out_corrected_bed, self.args, print_corrected=True)
-        printer_list = [self.basic_printer, self.corrected_bed_printer]
+        printer_list = [self.corrected_bed_printer]
+        if self.args.genedb:
+            self.basic_printer = BasicTSVAssignmentPrinter(sample.out_assigned_tsv, self.args, self.io_support,
+                                                           additional_header=self.common_header)
+            printer_list.append(self.basic_printer)
         if self.args.sqanti_output:
             self.sqanti_printer = SqantiTSVPrinter(sample.out_alt_tsv, self.args, self.io_support)
             printer_list.append(self.sqanti_printer)
@@ -506,8 +508,9 @@ class DatasetProcessor:
                 self.global_counter.add_counters([self.gene_grouped_counter, self.transcript_grouped_counter])
 
     def merge_assignments(self, sample, chr_ids):
-        merge_files([rreplace(sample.out_assigned_tsv, sample.label, sample.label + "_" + chr_id) for chr_id in chr_ids],
-                    sample.out_assigned_tsv, copy_header=False)
+        if self.args.genedb:
+            merge_files([rreplace(sample.out_assigned_tsv, sample.label, sample.label + "_" + chr_id) for chr_id in chr_ids],
+                        sample.out_assigned_tsv, copy_header=False)
         merge_files([rreplace(sample.out_corrected_bed, sample.label, sample.label + "_" + chr_id) for chr_id in chr_ids],
                     sample.out_corrected_bed, copy_header=False)
         for p in self.global_counter.counters:
@@ -534,6 +537,7 @@ class DatasetProcessor:
     def finalize_aggregators(self, sample):
         logger.info("Gene counts are stored in " + self.gene_counter.output_counts_file_name)
         logger.info("Transcript counts are stored in " + self.transcript_counter.output_counts_file_name)
-        logger.info("Read assignments are stored in " + self.basic_printer.output_file_name)
+        if self.args.genedb:
+            logger.info("Read assignments are stored in " + self.basic_printer.output_file_name)
         self.read_stat_counter.print_start("Read assignment statistics")
 

--- a/src/dataset_processor.py
+++ b/src/dataset_processor.py
@@ -71,10 +71,7 @@ def collect_reads_in_parallel(sample, chr_id, args, read_grouper, current_chr_re
     logger.info("Processing chromosome " + chr_id)
     alignment_collector = IntergenicAlignmentCollector(chr_id, bam_file_pairs, args, gffutils_db, current_chr_record, read_grouper)
 
-    if args.low_memory:
-        alignment_iterator = alignment_collector.process_slow()
-    else:
-        alignment_iterator = alignment_collector.process()
+    alignment_iterator = alignment_collector.process()
     for gene_info, assignment_storage in alignment_iterator:
         tmp_printer.add_gene_info(gene_info)
         for read_assignment in assignment_storage:

--- a/src/gene_info.py
+++ b/src/gene_info.py
@@ -153,6 +153,7 @@ class GeneInfo:
         self.gene_attributes = {}
         self.set_gene_attributes()
         # self.detect_ambiguous()
+        # TODO remove obsolote
         self.regions_for_bam_fetch = self.get_regions_for_bam_fetch(self.split_exon_profiles.features)
         self.exon_property_map = self.set_feature_properties(self.all_isoforms_exons, self.exon_profiles)
         self.intron_property_map = self.set_feature_properties(self.all_isoforms_introns, self.intron_profiles)

--- a/src/isoform_assignment.py
+++ b/src/isoform_assignment.py
@@ -279,7 +279,6 @@ def elongation_cost(params, elongation_len):
     elif elongation_len >= upper_bound:
         return max_cost
     else:
-        logger.debug(str(elongation_len) + ", " + str(lower_bound) + "," + str(upper_bound) + ", " + str((elongation_len - lower_bound) / (upper_bound - lower_bound)))
         return min_cost + (max_cost - min_cost) * (elongation_len - lower_bound) / (upper_bound - lower_bound)
 
 
@@ -382,26 +381,23 @@ class IsoformMatch:
 
 
 class BasicReadAssignment:
-    def __init__(self, read_assignment, gene_info):
+    def __init__(self, read_assignment):
+        self.assignment_id = read_assignment.assignment_id
         self.read_id = read_assignment.read_id
         self.chr_id = read_assignment.chr_id
-        self.start = read_assignment.start()
-        self.end = read_assignment.end()
-        self.gene_id = gene_info.gene_db_list[0].id if gene_info.gene_db_list else ""
         self.multimapper = read_assignment.multimapper
         self.polyA_found = read_assignment.polyA_found
         self.assignment_type = read_assignment.assignment_type
         if read_assignment.isoform_matches:
             self.score = read_assignment.isoform_matches[0].score
-            self.matches = len(read_assignment.isoform_matches)
         else:
-            self.matches = 0
             self.score = 0.0
-        self.read_group = read_assignment.read_group
 
 
 class ReadAssignment:
+    assignment_id_generator = AtomicCounter()
     def __init__(self, read_id, assignment_type, match=None):
+        self.assignment_id = ReadAssignment.assignment_id_generator.increment()
         self.read_id = read_id
         self.exons = None
         self.corrected_exons = None
@@ -525,9 +521,6 @@ def match_subtype_to_str_with_additional_info(event, strand, read_introns, isofo
         if event.read_region != SupplementaryMatchConstansts.undefined_region and \
                 event.read_region[0] >= 0 and event.read_region[1] >= 0:
             introns = read_introns[event.read_region[0]:event.read_region[1]+1]
-            # logger.debug(read_introns)
-            # logger.debug("+ adding info for %s, introns indices %s, introns %s" %
-            #              (str(event.event_type), str(event.read_region), str(introns)))
             additional_info = ":" + regions_to_str(introns)
 
     return match_subtype_to_str(event, strand) + additional_info

--- a/src/long_read_assigner.py
+++ b/src/long_read_assigner.py
@@ -394,7 +394,7 @@ class LongReadAssigner:
                 or all(el == 0 or el == -2 for el in read_split_exon_profile.gene_profile):
             read_region = (read_split_exon_profile.read_features[0][0], read_split_exon_profile.read_features[-1][1])
             gene_region = (self.gene_info.split_exon_profiles.features[0][0],
-                              self.gene_info.split_exon_profiles.features[-1][1])
+                           self.gene_info.split_exon_profiles.features[-1][1])
             # none of the blocks matched
             if not overlaps(read_region, gene_region):
                 # logger.debug("EMPTY - noninformative")

--- a/src/multimap_resolver.py
+++ b/src/multimap_resolver.py
@@ -51,7 +51,6 @@ class MultimapResolver:
 
     def select_best_assignment(self, assignment_list):
         logger.debug("Resolving read %s" % assignment_list[0].read_id)
-        logger.debug("Read assignment types %s" % " ".join(a.assignment_type.name for a in assignment_list))
         primary_unique = set()
         consistent_assignments = set()
         inconsistent_assignments = set()
@@ -71,40 +70,30 @@ class MultimapResolver:
 
         if primary_unique:
             if len(primary_unique) > 1:
-                # TODO silence warn
-                logger.debug("Multiple primary unique %s: %s " % (assignment_list[0].read_id, ",".join([assignment_list[i].gene_id for i in primary_unique])))
                 return self.suspend_assignments(assignment_list, primary_unique, ReadAssignmentType.ambiguous)
             # primary unique is found, rest is noninformative
-            logger.debug("Primary unique assignment selected: %s" %
-                         " ".join([assignment_list[i].gene_id for i in primary_unique]))
             return self.suspend_assignments(assignment_list, primary_unique)
 
         if consistent_assignments:
-            logger.debug("Merging %d consistent assignments " % len(consistent_assignments))
             return self.suspend_assignments(assignment_list, consistent_assignments, ReadAssignmentType.ambiguous)
 
         if primary_inconsistent:
             return self.select_best_inconsistent(assignment_list, primary_inconsistent)
 
-        logger.debug("Merging inconsistent from %d assignments" % len(inconsistent_assignments))
         if inconsistent_assignments:
             return self.select_best_inconsistent(assignment_list, inconsistent_assignments)
         return assignment_list
 
     def select_best_inconsistent(self, assignment_list, inconsistent_assignments):
         if len(inconsistent_assignments) > 1:
-            logger.debug("= Multiple primary inconsistent " +
-                         ",".join([assignment_list[i].gene_id for i in inconsistent_assignments]))
             assignment_scores = []
             for i in inconsistent_assignments:
                 assignment_scores.append((assignment_list[i].score, i))
             best_score = min(assignment_scores, key=lambda x: x[0])[0]
-            logger.debug("= Best score " + str(best_score))
             best_isoforms = [x[1] for x in filter(lambda x: x[0] == best_score, assignment_scores)]
             return self.suspend_assignments(assignment_list, best_isoforms,
                                             ReadAssignmentType.inconsistent if len(best_isoforms) > 1 else None)
 
-        logger.debug("Primary inconsistent assignment selected")
         return self.suspend_assignments(assignment_list, inconsistent_assignments)
 
     def suspend_assignments(self, assignment_list, assignments_to_keep, new_type=None):

--- a/tests/teamcity/run_pipeline.py
+++ b/tests/teamcity/run_pipeline.py
@@ -135,7 +135,7 @@ def run_isoquant(args, config_dict, log):
 
         log.start_block('isoquant', 'Running IsoQuant')
         isoquant_command_list = ["python3", os.path.join(isoquant_dir, "isoquant.py"), "-o", output_folder,
-                                 "-r", genome, "-d", config_dict["datatype"], "-t", "16", "-l", run_name]
+                                 "-r", genome, "-d", config_dict["datatype"], "-l", run_name]
         if genedb:
             isoquant_command_list += ["--genedb", genedb]
         if "bam" in config_dict:


### PR DESCRIPTION
- Split genomic regions into smaller ones only when GTF is provided for the sake of faster read-to-isoform assignment
- Improve splitting by considering amount of reads and number of introns
- Synchronize low-memory and usual mode 
- Use more iterators