### PR TITLE
cleaning up imports

### DIFF
--- a/isoquant.py
+++ b/isoquant.py
@@ -5,17 +5,35 @@
 # # All Rights Reserved
 # See file LICENSE for details.
 ############################################################################
+import argparse
 import glob
+import json
 import logging
 import os.path
+import pickle
 import sys
-from io import StringIO
 import time
+from collections import namedtuple
+from io import StringIO
+from traceback import print_exc
 
-from src.gtf2db import *
-from src.read_mapper import *
-from src.dataset_processor import *
+import pysam
+from src.gtf2db import convert_gtf_to_db
+from src.read_mapper import (
+    DATA_TYPE_ALIASES,
+    SUPPORTED_STRANDEDNESS,
+    SUPPORTED_ALIGNERS,
+    ASSEMBLY,
+    PACBIO_CCS_DATA,
+    NANOPORE_DATA,
+    DataSetReadMapper
+)
+from src.dataset_processor import DatasetProcessor
+from src.long_read_assigner import AmbiguityResolvingMethod
 from src.long_read_counter import COUNTING_STRATEGIES
+from src.input_data_storage import InputDataStorage
+from src.multimap_resolver import MultimapResolvingStrategy
+from src.stats import combine_counts
 
 logger = logging.getLogger('IsoQuant')
 

--- a/isoquant.py
+++ b/isoquant.py
@@ -9,7 +9,6 @@ import glob
 import logging
 import os.path
 import sys
-from shutil import rmtree
 from io import StringIO
 import time
 

--- a/misc/assess_quantification.py
+++ b/misc/assess_quantification.py
@@ -1,12 +1,7 @@
 #!/usr/bin/env python3
 import os
-import subprocess
 import argparse
-import pathlib
 
-from collections import Counter
-
-import pandas as pd
 import numpy as np
 
 

--- a/misc/common.py
+++ b/misc/common.py
@@ -6,16 +6,9 @@
 # See file LICENSE for details.
 ############################################################################
 
-import os
 import subprocess
-import sys
-import argparse
 from collections import defaultdict
-from traceback import print_exc
-from collections import namedtuple
 
-import pysam
-import gffutils
 from enum import Enum, unique
 
 

--- a/misc/denovo_analyse.py
+++ b/misc/denovo_analyse.py
@@ -7,11 +7,9 @@
 
 import sys
 import os
-import shutil
-import random
 import argparse
 from traceback import print_exc
-from common import *
+
 
 def parse_args():
     parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter)

--- a/misc/denovo_model_stats.py
+++ b/misc/denovo_model_stats.py
@@ -7,8 +7,6 @@
 
 import sys
 import os
-import shutil
-import random
 import argparse
 from traceback import print_exc
 from common import *

--- a/misc/reduced_db_gffcompare.py
+++ b/misc/reduced_db_gffcompare.py
@@ -7,16 +7,10 @@
 ############################################################################
 
 import os
-import subprocess
 import sys
 import argparse
-from collections import defaultdict
 from traceback import print_exc
-from collections import namedtuple
 
-import pysam
-import gffutils
-from enum import Enum, unique
 from common import *
 
 

--- a/misc/split_gffcompare.py
+++ b/misc/split_gffcompare.py
@@ -7,16 +7,10 @@
 ############################################################################
 
 import os
-import subprocess
 import sys
 import argparse
-from collections import defaultdict
 from traceback import print_exc
-from collections import namedtuple
 
-import pysam
-import gffutils
-from enum import Enum, unique
 from common import *
 
 

--- a/misc/tpm_stats_precision.py
+++ b/misc/tpm_stats_precision.py
@@ -6,14 +6,10 @@
 # See file LICENSE for details.
 ############################################################################
 
-import os
-import subprocess
 import sys
 import argparse
 from collections import defaultdict
 from traceback import print_exc
-from enum import Enum, unique
-from common import *
 
 
 def parse_args():

--- a/misc/tpm_stats_recall.py
+++ b/misc/tpm_stats_recall.py
@@ -6,14 +6,10 @@
 # See file LICENSE for details.
 ############################################################################
 
-import os
-import subprocess
 import sys
 import argparse
 from collections import defaultdict
 from traceback import print_exc
-from enum import Enum, unique
-from common import *
 
 
 def parse_args():

--- a/src/10x_profiles.py
+++ b/src/10x_profiles.py
@@ -5,7 +5,7 @@
 ############################################################################
 
 import logging
-from common import *
+from common import concat_gapless_blocks
 
 logger = logging.getLogger('10XProfile')
 

--- a/src/alignment_info.py
+++ b/src/alignment_info.py
@@ -6,8 +6,8 @@
 
 import logging
 
-from src.polya_finder import *
-from src.polya_verification import *
+from .common import get_read_blocks
+from .polya_verification import shift_polya, shift_polyt
 
 logger = logging.getLogger('IsoQuant')
 

--- a/src/alignment_info.py
+++ b/src/alignment_info.py
@@ -5,8 +5,6 @@
 ############################################################################
 
 import logging
-import pysam
-from Bio import SeqIO
 
 from src.polya_finder import *
 from src.polya_verification import *

--- a/src/alignment_processor.py
+++ b/src/alignment_processor.py
@@ -5,9 +5,7 @@
 ############################################################################
 
 import logging
-import pysam
-from queue import PriorityQueue, Empty
-from Bio import SeqIO
+from queue import PriorityQueue
 
 from src.long_read_assigner import *
 from src.long_read_profiles import *

--- a/src/alignment_processor.py
+++ b/src/alignment_processor.py
@@ -5,15 +5,26 @@
 ############################################################################
 
 import logging
+from collections import defaultdict
 from queue import PriorityQueue
 
-from src.long_read_assigner import *
-from src.long_read_profiles import *
-from src.read_groups import *
-from src.polya_finder import *
-from src.polya_verification import *
-from src.exon_corrector import *
-from src.alignment_info import *
+from .common import interval_len, junctions_from_blocks, overlaps
+from .gene_info import GeneInfo, StrandDetector
+from .long_read_assigner import LongReadAssigner
+from .long_read_profiles import CombinedProfileConstructor
+from .isoform_assignment import (
+    IsoformMatch,
+    MatchClassification,
+    MatchEvent,
+    MatchEventSubtype,
+    ReadAssignment,
+    ReadAssignmentType,
+)
+from .read_groups import DefaultReadGrouper
+from .polya_finder import PolyAFinder, CagePeakFinder
+from .polya_verification import PolyAFixer
+from .exon_corrector import ExonCorrector
+from .alignment_info import AlignmentInfo
 
 logger = logging.getLogger('IsoQuant')
 

--- a/src/alignment_refiner.py
+++ b/src/alignment_refiner.py
@@ -5,9 +5,7 @@
 ############################################################################
 
 import logging
-from collections import namedtuple
 
-import pysam
 from Bio import pairwise2
 
 from src.isoform_assignment import *

--- a/src/alignment_refiner.py
+++ b/src/alignment_refiner.py
@@ -8,9 +8,7 @@ import logging
 
 from Bio import pairwise2
 
-from src.isoform_assignment import *
-from src.gene_info import *
-from src.long_read_profiles import *
+from .isoform_assignment import MatchEventSubtype
 
 logger = logging.getLogger('IsoQuant')
 pairwise2.MAX_ALIGNMENTS = 1

--- a/src/assignment_io.py
+++ b/src/assignment_io.py
@@ -4,8 +4,20 @@
 # See file LICENSE for details.
 ############################################################################
 
+import logging
 import pickle
-from src.long_read_assigner import *
+
+from .common import (
+    CANONICAL_FWD_SITES,
+    CANONICAL_REV_SITES,
+    argmin,
+    junctions_from_blocks,
+    range_list_to_str,
+    sum_intervals_from_point,
+    sum_intervals_to_point
+)
+from .isoform_assignment import match_subtype_to_str_with_additional_info
+from .long_read_assigner import ReadAssignmentType
 
 
 logger = logging.getLogger('IsoQuant')

--- a/src/assignment_io.py
+++ b/src/assignment_io.py
@@ -4,7 +4,7 @@
 # See file LICENSE for details.
 ############################################################################
 
-import _pickle as pickle
+import pickle
 from src.long_read_assigner import *
 
 

--- a/src/dataset_processor.py
+++ b/src/dataset_processor.py
@@ -4,24 +4,48 @@
 # See file LICENSE for details.
 ############################################################################
 
-import pickle
 import gc
 import glob
 import gzip
-import os
-import time
-from multiprocessing import Pool
 import itertools
+import logging
+import os
+import pickle
+import shutil
+import time
+from collections import defaultdict
+from multiprocessing import Pool
 
-from src.file_utils import *
-from src.input_data_storage import *
-from src.alignment_processor import *
-from src.long_read_counter import *
-from src.multimap_resolver import *
-from src.read_groups import *
-from src.transcript_printer import *
-from src.stats import *
-from src.graph_based_model_construction import *
+import gffutils
+import pysam
+import Bio.SeqIO as SeqIO
+
+from .common import proper_plural_form, rreplace
+from .isoform_assignment import BasicReadAssignment, ReadAssignment, ReadAssignmentType
+from .gene_info import GeneInfo
+from .stats import EnumStats
+from .file_utils import merge_files
+from .input_data_storage import SampleData
+from .alignment_processor import IntergenicAlignmentCollector
+from .long_read_counter import (
+    ExonCounter,
+    IntronCounter,
+    CompositeCounter,
+    create_gene_counter,
+    create_transcript_counter,
+)
+from .multimap_resolver import MultimapResolver
+from .read_groups import create_read_grouper
+from .assignment_io import (
+    IOSupport,
+    BEDPrinter,
+    ReadAssignmentCompositePrinter,
+    SqantiTSVPrinter,
+    BasicTSVAssignmentPrinter,
+    TmpFileAssignmentPrinter,
+)
+from .transcript_printer import GFFPrinter
+from .graph_based_model_construction import GraphBasedModelConstructor
 
 
 logger = logging.getLogger('IsoQuant')

--- a/src/dataset_processor.py
+++ b/src/dataset_processor.py
@@ -4,7 +4,7 @@
 # See file LICENSE for details.
 ############################################################################
 
-import _pickle as pickle
+import pickle
 import gc
 import glob
 import gzip

--- a/src/exon_corrector.py
+++ b/src/exon_corrector.py
@@ -5,7 +5,6 @@
 ############################################################################
 
 import logging
-from collections import namedtuple
 
 from src.common import *
 from src.gene_info import *

--- a/src/exon_corrector.py
+++ b/src/exon_corrector.py
@@ -5,11 +5,11 @@
 ############################################################################
 
 import logging
+from functools import partial
 
-from src.common import *
-from src.gene_info import *
-from src.isoform_assignment import *
-from src.long_read_profiles import *
+from .common import equal_ranges, junctions_from_blocks, contains_well_inside
+from .isoform_assignment import ReadAssignmentType, MatchEventSubtype, SupplementaryMatchConstants
+from .long_read_profiles import OverlappingFeaturesProfileConstructor
 
 logger = logging.getLogger('IsoQuant')
 
@@ -81,9 +81,9 @@ class ExonCorrector:
     def correct_misalignments(self, alignment_info, read_assignment):
         event_map = {}
         for e in read_assignment.isoform_matches[0].match_subclassifications:
-            if e.read_region == SupplementaryMatchConstansts.undefined_region:
+            if e.read_region == SupplementaryMatchConstants.undefined_region:
                 continue
-            if e.read_region[0] == SupplementaryMatchConstansts.absent_position:
+            if e.read_region[0] == SupplementaryMatchConstants.absent_position:
                 if e.event_type == MatchEventSubtype.fake_micro_intron_retention and \
                         self.params.correct_microintron_retention:
                     event_map[-e.read_region[1]-1] = e

--- a/src/file_utils.py
+++ b/src/file_utils.py
@@ -2,9 +2,6 @@ import logging
 import os
 import re
 import shutil
-from collections import defaultdict
-
-from src.read_groups import AbstractReadGrouper
 
 logger = logging.getLogger('IsoQuant')
 

--- a/src/gene_info.py
+++ b/src/gene_info.py
@@ -5,11 +5,9 @@
 ############################################################################
 
 import logging
-import gffutils
 from enum import Enum, unique
 from functools import partial
-from collections import defaultdict
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 
 from src.common import *
 

--- a/src/gene_info.py
+++ b/src/gene_info.py
@@ -9,7 +9,15 @@ from enum import Enum, unique
 from functools import partial
 from collections import OrderedDict, defaultdict
 
-from src.common import *
+from .common import (
+    contains,
+    equal_ranges,
+    get_intron_strand,
+    intervals_total_length,
+    is_subprofile,
+    overlaps,
+    junctions_from_blocks,
+)
 
 logger = logging.getLogger('IsoQuant')
 

--- a/src/graph_based_model_construction.py
+++ b/src/graph_based_model_construction.py
@@ -6,10 +6,7 @@
 
 import logging
 from collections import defaultdict
-from collections import namedtuple
-from functools import reduce
 from functools import cmp_to_key
-import copy
 
 from src.common import *
 from src.assignment_io import *

--- a/src/graph_based_model_construction.py
+++ b/src/graph_based_model_construction.py
@@ -8,12 +8,24 @@ import logging
 from collections import defaultdict
 from functools import cmp_to_key
 
-from src.common import *
-from src.assignment_io import *
-from src.isoform_assignment import *
-from src.intron_graph import *
-from src.gene_info import *
-from src.alignment_info import *
+from .common import (
+    AtomicCounter,
+    cmp,
+    get_exons,
+    get_top_count,
+    intersection_len,
+    interval_len,
+    junctions_from_blocks,
+    read_coverage_fraction,
+)
+from .assignment_io import ReadAssignmentType
+from .gene_info import GeneInfo, StrandDetector, TranscriptModel, TranscriptModelType
+from .intron_graph import IntronGraph, VERTEX_polya, VERTEX_polyt, VERTEX_read_end, VERTEX_read_start
+from .isoform_assignment import is_matching_assignment, match_subtype_to_str_with_additional_info, MatchEventSubtype
+from .long_read_assigner import LongReadAssigner
+from .long_read_profiles import CombinedProfileConstructor
+from .polya_finder import PolyAInfo
+
 
 logger = logging.getLogger('IsoQuant')
 

--- a/src/gtf2db.py
+++ b/src/gtf2db.py
@@ -9,7 +9,6 @@
 import json
 import logging
 import os
-import sys
 import gffutils
 import argparse
 from traceback import print_exc

--- a/src/gtf_stats.py
+++ b/src/gtf_stats.py
@@ -14,7 +14,6 @@ from traceback import print_exc
 
 import gffutils
 from Bio import SeqIO
-from Bio import Seq
 from collections import defaultdict
 from gtf2db import *
 from common import *

--- a/src/gtf_stats.py
+++ b/src/gtf_stats.py
@@ -15,8 +15,9 @@ from traceback import print_exc
 import gffutils
 from Bio import SeqIO
 from collections import defaultdict
-from gtf2db import *
-from common import *
+
+from .common import junctions_from_blocks
+from .gtf2db import convert_gtf_to_db
 
 
 logger = logging.getLogger('IsoQuant')

--- a/src/input_data_storage.py
+++ b/src/input_data_storage.py
@@ -5,7 +5,6 @@
 ############################################################################
 
 import os
-import sys
 import logging
 
 logger = logging.getLogger('IsoQuant')

--- a/src/intron_graph.py
+++ b/src/intron_graph.py
@@ -8,7 +8,7 @@ import logging
 import queue
 from collections import defaultdict
 
-from src.common import *
+from .common import find_closest, overlaps
 
 logger = logging.getLogger('IsoQuant')
 

--- a/src/intron_graph.py
+++ b/src/intron_graph.py
@@ -7,7 +7,6 @@
 import logging
 import queue
 from collections import defaultdict
-from enum import Enum, unique
 
 from src.common import *
 

--- a/src/isoform_assignment.py
+++ b/src/isoform_assignment.py
@@ -6,9 +6,7 @@
 
 import logging
 from enum import Enum, unique
-from collections import namedtuple
 
-from src.common import *
 
 logger = logging.getLogger('IsoQuant')
 

--- a/src/isoform_assignment.py
+++ b/src/isoform_assignment.py
@@ -323,7 +323,7 @@ alternative_sites = {("left", True): MatchEventSubtype.alt_left_site_known,
                      ("right", False): MatchEventSubtype.alt_right_site_novel}
 
 
-class SupplementaryMatchConstansts:
+class SupplementaryMatchConstants:
     extra_left_mod_position = -1000000
     extra_right_mod_position = 1000000
     undefined_position = -2000000
@@ -335,8 +335,8 @@ class SupplementaryMatchConstansts:
 
 class MatchEvent:
     def __init__(self, event_type:MatchEventSubtype,
-                 isoform_region:tuple=SupplementaryMatchConstansts.undefined_region,
-                 read_region:tuple=SupplementaryMatchConstansts.undefined_region,
+                 isoform_region:tuple=SupplementaryMatchConstants.undefined_region,
+                 read_region:tuple=SupplementaryMatchConstants.undefined_region,
                  event_info=0):
         self.event_type = event_type
         self.isoform_region = isoform_region
@@ -508,7 +508,7 @@ def match_subtype_to_str_with_additional_info(event, strand, read_introns, isofo
                          MatchEventSubtype.incomplete_intron_retention_left,
                          MatchEventSubtype.incomplete_intron_retention_right,
                          MatchEventSubtype.fake_micro_intron_retention}:
-        if event.isoform_region != SupplementaryMatchConstansts.undefined_region:
+        if event.isoform_region != SupplementaryMatchConstants.undefined_region:
             introns = isoform_introns[event.isoform_region[0]:event.isoform_region[1]+1]
             additional_info = ":" + regions_to_str(introns)
     elif event_subtype in {MatchEventSubtype.major_exon_elongation_left, MatchEventSubtype.major_exon_elongation_right,
@@ -520,7 +520,7 @@ def match_subtype_to_str_with_additional_info(event, strand, read_introns, isofo
         # elongation events
         additional_info = ":" + str(event.event_info)
     else:
-        if event.read_region != SupplementaryMatchConstansts.undefined_region and \
+        if event.read_region != SupplementaryMatchConstants.undefined_region and \
                 event.read_region[0] >= 0 and event.read_region[1] >= 0:
             introns = read_introns[event.read_region[0]:event.read_region[1]+1]
             # logger.debug(read_introns)

--- a/src/junction_comparator.py
+++ b/src/junction_comparator.py
@@ -5,7 +5,6 @@
 ############################################################################
 
 import logging
-from collections import namedtuple
 
 from src.isoform_assignment import *
 from src.gene_info import *

--- a/src/long_read_assigner.py
+++ b/src/long_read_assigner.py
@@ -6,12 +6,36 @@
 
 import logging
 from collections import namedtuple
+from enum import Enum, unique
+from functools import partial
 
-from src.isoform_assignment import *
-from src.gene_info import *
-from src.long_read_profiles import *
-from src.junction_comparator import *
-from src.polya_verification import *
+from .common import (
+    contains,
+    difference_in_present_features,
+    equal_ranges,
+    extra_exon_percentage,
+    has_overlapping_features,
+    jaccard_similarity,
+    overlap_intervals,
+    overlaps,
+    read_coverage_fraction,
+    rindex,
+)
+from .isoform_assignment import (
+    IsoformMatch,
+    MatchEvent,
+    MatchEventSubtype,
+    MatchClassification,
+    ReadAssignment,
+    ReadAssignmentType,
+    SupplementaryMatchConstants,
+    event_subtype_cost,
+    elongation_cost,
+)
+from .long_read_profiles import OverlappingFeaturesProfileConstructor
+from .junction_comparator import JunctionComparator
+from .polya_verification import PolyAVerifier
+
 
 logger = logging.getLogger('IsoQuant')
 
@@ -671,12 +695,12 @@ class LongReadAssigner:
             score = 0.0
             for e in match_events:
                 event_count = 1
-                if e.isoform_region != SupplementaryMatchConstansts.undefined_region and \
-                        SupplementaryMatchConstansts.absent_position not in e.isoform_region and \
+                if e.isoform_region != SupplementaryMatchConstants.undefined_region and \
+                        SupplementaryMatchConstants.absent_position not in e.isoform_region and \
                         e.event_type in {MatchEventSubtype.exon_skipping_known, MatchEventSubtype.exon_skipping_novel}:
                     event_count = e.isoform_region[1] - e.isoform_region[0] + 1
-                elif e.read_region != SupplementaryMatchConstansts.undefined_region and \
-                        SupplementaryMatchConstansts.absent_position not in e.read_region:
+                elif e.read_region != SupplementaryMatchConstants.undefined_region and \
+                        SupplementaryMatchConstants.absent_position not in e.read_region:
                     event_count = e.read_region[1] - e.read_region[0] + 1
                     if e.event_type in {MatchEventSubtype.exon_gain_novel,
                                         MatchEventSubtype.exon_gain_known,

--- a/src/long_read_counter.py
+++ b/src/long_read_counter.py
@@ -4,9 +4,18 @@
 # See file LICENSE for details.
 ############################################################################
 
-from src.isoform_assignment import *
-from src.gene_info import *
-from src.read_groups import *
+import logging
+from collections import defaultdict
+from enum import Enum, unique
+
+from .isoform_assignment import (
+    ReadAssignmentType,
+    nonintronic_events,
+    get_assigned_gene_id,
+    get_assigned_transcript_id
+)
+from .gene_info import FeatureInfo
+from .read_groups import AbstractReadGrouper
 
 logger = logging.getLogger('IsoQuant')
 

--- a/src/long_read_profiles.py
+++ b/src/long_read_profiles.py
@@ -8,7 +8,14 @@ import logging
 from functools import partial
 from collections import defaultdict
 
-from src.common import *
+from .common import (
+    contains,
+    equal_ranges,
+    junctions_from_blocks,
+    left_of,
+    overlaps,
+    overlaps_at_least,
+)
 
 logger = logging.getLogger('IsoQuant')
 

--- a/src/multimap_resolver.py
+++ b/src/multimap_resolver.py
@@ -7,8 +7,7 @@
 import logging
 from enum import Enum
 
-from src.common import *
-from src.isoform_assignment import *
+from .isoform_assignment import ReadAssignmentType
 
 logger = logging.getLogger('IsoQuant')
 

--- a/src/multimap_resolver.py
+++ b/src/multimap_resolver.py
@@ -6,7 +6,6 @@
 
 import logging
 from enum import Enum
-from collections import defaultdict
 
 from src.common import *
 from src.isoform_assignment import *

--- a/src/polya_finder.py
+++ b/src/polya_finder.py
@@ -5,7 +5,6 @@
 ############################################################################
 
 import logging
-from functools import partial
 
 import pybedtools as pbt
 from Bio import Seq

--- a/src/polya_verification.py
+++ b/src/polya_verification.py
@@ -7,9 +7,8 @@
 import logging
 import math
 
-from src.isoform_assignment import *
-from src.gene_info import *
-from src.long_read_profiles import *
+from .common import interval_len, intervals_total_length
+from .isoform_assignment import MatchEvent, MatchEventSubtype
 
 logger = logging.getLogger('IsoQuant')
 

--- a/src/read_groups.py
+++ b/src/read_groups.py
@@ -6,7 +6,7 @@
 
 import logging
 import gzip
-from src.common import *
+import os
 
 logger = logging.getLogger('IsoQuant')
 

--- a/src/read_mapper.py
+++ b/src/read_mapper.py
@@ -3,7 +3,6 @@ import os
 import subprocess
 import json
 import pysam
-from Bio import SeqIO
 from src.common import get_path_to_program
 from src.gtf2db import *
 from src.input_data_storage import SampleData

--- a/src/read_mapper.py
+++ b/src/read_mapper.py
@@ -3,9 +3,10 @@ import os
 import subprocess
 import json
 import pysam
-from src.common import get_path_to_program
-from src.gtf2db import *
-from src.input_data_storage import SampleData
+
+from .common import get_path_to_program
+from .gtf2db import convert_db_to_gtf, db2bed
+from .input_data_storage import SampleData
 
 logger = logging.getLogger('IsoQuant')
 

--- a/src/stats.py
+++ b/src/stats.py
@@ -11,7 +11,7 @@ import pickle
 
 import pandas as pd
 
-from src.common import proper_plural_form
+from .common import proper_plural_form
 
 
 logger = logging.getLogger('IsoQuant')

--- a/src/stats.py
+++ b/src/stats.py
@@ -7,7 +7,7 @@
 import os
 import logging
 from collections import defaultdict
-import _pickle as pickle
+import pickle
 
 import pandas as pd
 

--- a/src/transcript_printer.py
+++ b/src/transcript_printer.py
@@ -5,13 +5,11 @@
 ############################################################################
 
 import logging
+import os
 from collections import defaultdict
 from collections import namedtuple
 
-from src.common import *
-from src.assignment_io import *
-from src.long_read_assigner import *
-from src.gene_info import *
+from .common import AtomicCounter, junctions_from_blocks, max_range
 
 logger = logging.getLogger('IsoQuant')
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,24 +1,24 @@
 import pytest
 
-from src.common import *
+import src.common as c
 
 
 class TestMiscFunction:
     def test_get_first(self):
-        assert get_first_best_from_sorted([(1,1), (2,2), (3,3)]) == [1]
-        assert get_first_best_from_sorted([(1,1), (2,1), (3,3)]) == [1, 2]
+        assert c.get_first_best_from_sorted([(1,1), (2,2), (3,3)]) == [1]
+        assert c.get_first_best_from_sorted([(1,1), (2,1), (3,3)]) == [1, 2]
 
     @pytest.mark.parametrize("collection, elem, expected",
                              [([0, 1, 2], 2, 2), ([0, 1, 2], 0, 0), ([0, 1, 2], 1, 1), ([1, 1, 0], 1, 1),
                               ([1, 1, 1], 1, 2)],
                              ids=("last", "first", "middle", "several", "all"))
     def test_correct(self, collection, elem, expected):
-        assert expected == rindex(collection, elem)
+        assert expected == c.rindex(collection, elem)
 
     @pytest.mark.parametrize("collection", [(), ("b", "c")])
     def test_no_such_elem(self, collection):
         with pytest.raises(ValueError, match="a is not in list"):
-            rindex(collection, "a")
+            c.rindex(collection, "a")
 
 
 class TestRanges:
@@ -26,64 +26,64 @@ class TestRanges:
                              [((1, 20), (1, 20), 0, True), ((1, 20), (2, 21), 1, True), ((1, 10), (1, 20), 5, False)],
                              ids=("equals", "less_than_delta", "bigger_than_delta"))
     def test_equal(self, range1, range2, delta, expected):
-        assert expected == equal_ranges(range1, range2, delta)
+        assert expected == c.equal_ranges(range1, range2, delta)
 
     @pytest.mark.parametrize("range1, range2, expected",
                              [((1, 20), (1, 20), True), ((1, 20), (20, 121), True), ((1, 10), (11, 20), False),
                               ((111, 210), (11, 110), False), ((120, 210), (101, 121), True)])
     def test_overlaps(self, range1, range2, expected):
-        assert expected == overlaps(range1, range2)
+        assert expected == c.overlaps(range1, range2)
 
     @pytest.mark.parametrize("range1, range2, delta, expected",
                              [((1, 20), (20, 25), 0, True), ((18, 120), (2, 20), 3, True), ((1, 10), (6, 20), 6, False)])
     def test_overlaps_at_least(self, range1, range2, delta, expected):
-        assert expected == overlaps_at_least(range1, range2, delta)
+        assert expected == c.overlaps_at_least(range1, range2, delta)
 
     @pytest.mark.parametrize("range1, range2, delta, expected",
                              [((1, 25), (20, 25), 0, True), ((18, 40), (16, 41), 3, True), ((10, 27), (5, 30), 4, False)])
     def test_contains_approx(self, range1, range2, delta, expected):
-        assert expected == contains_approx(range1, range2, delta)
+        assert expected == c.contains_approx(range1, range2, delta)
 
     @pytest.mark.parametrize("range1, range2, expected",
                              [((1, 20), (1, 20), True), ((1, 120), (20, 101), True), ((1, 10), (11, 20), False),
                               ((111, 210), (111, 211), False), ((120, 210), (119, 121), False)])
     def test_contains(self, range1, range2, expected):
-        assert expected == contains(range1, range2)
+        assert expected == c.contains(range1, range2)
 
 
     @pytest.mark.parametrize("range1, range2, expected",
                              [((1, 20), (1, 20), True), ((1, 120), (20, 201), False), ((1, 10), (11, 20), False),
                               ((111, 210), (111, 211), False), ((120, 210), (119, 201), True)])
     def test_covers_start(self, range1, range2, expected):
-        assert expected == covers_start(range1, range2)
+        assert expected == c.covers_start(range1, range2)
 
     @pytest.mark.parametrize("range1, range2, expected",
                              [((1, 20), (1, 20), True), ((1, 120), (20, 201), True), ((1, 10), (11, 20), False),
                               ((111, 210), (111, 211), True), ((120, 210), (121, 211), True)])
     def test_covers_end(self, range1, range2, expected):
-        assert expected == covers_end(range1, range2)
+        assert expected == c.covers_end(range1, range2)
 
     @pytest.mark.parametrize("range, expected",
                              [((1, 20), 20), ((1, 1), 1)])
     def test_interval_len(self, range, expected):
-        assert expected == interval_len(range)
+        assert expected == c.interval_len(range)
 
     @pytest.mark.parametrize("ranges, expected",
                              [([(1, 20), (40, 50)], 31), ([(1, 1), (5, 5)], 2)])
     def test_intervals_len(self, ranges, expected):
-        assert expected == intervals_total_length(ranges)
+        assert expected == c.intervals_total_length(ranges)
 
     @pytest.mark.parametrize("ranges, point, expected",
                              [([(1, 20), (40, 50)], 60, 31), ([(1, 1), (5, 5)], 10, 2),
                               ([(1, 20), (40, 50)], 39, 20), ([(1, 20), (40, 50)], 41, 21)])
     def test_intervals_len_to_point(self, ranges, point, expected):
-        assert expected == sum_intervals_to_point(ranges, point)
+        assert expected == c.sum_intervals_to_point(ranges, point)
 
     @pytest.mark.parametrize("ranges, point, expected",
                              [([(1, 20), (40, 50)], 1, 30), ([(1, 1), (5, 5)], 0, 2),
                               ([(1, 20), (40, 50)], 39, 11), ([(1, 20), (40, 50)], 11, 20)])
     def test_intervals_len_from_point(self, ranges, point, expected):
-        assert expected == sum_intervals_from_point(ranges, point)
+        assert expected == c.sum_intervals_from_point(ranges, point)
 
 
 class TestSimilarityFunctions:
@@ -96,7 +96,7 @@ class TestSimilarityFunctions:
                               ([(146, 155), (160, 172)], [(1, 20), (41, 50), (61, 70)], 0.0),
                               ([(11, 20), (41, 50), (61, 70)], [(1, 4), (10, 12), (14, 16), (19, 30), (30, 34), (60, 70), (101, 149)], 0.17)])
     def test_jaccard_index(self, ranges1, ranges2, expected):
-        assert expected == jaccard_similarity(ranges1, ranges2)
+        assert expected == c.jaccard_similarity(ranges1, ranges2)
 
     @pytest.mark.parametrize("read_exons, isoform_exons, expected",
                              [([(1, 100)], [(31, 110)], 0.7),
@@ -107,7 +107,7 @@ class TestSimilarityFunctions:
                               ([(146, 155), (160, 172)], [(1, 20), (41, 50), (61, 70)], 0.0),
                               ([(11, 20), (41, 50), (61, 70), (201, 220)], [(1, 4), (10, 12), (14, 16), (19, 30), (30, 34), (60, 70), (101, 109)], 0.34)])
     def test_read_coverage_fraction(self, read_exons, isoform_exons, expected):
-        assert expected == read_coverage_fraction(read_exons, isoform_exons)
+        assert expected == c.read_coverage_fraction(read_exons, isoform_exons)
 
     @pytest.mark.parametrize("read_exons, isoform_region, expected",
                              [([(1, 100)], (31, 110), 0.3),
@@ -118,7 +118,7 @@ class TestSimilarityFunctions:
                               ([(1, 20), (41, 50), (61, 80)], (146, 172), 1.0),
                               ([(11, 20), (41, 50), (61, 90)], (16, 70), 0.5)])
     def test_extra_flanking(self, read_exons, isoform_region, expected):
-        assert expected == extra_exon_percentage(isoform_region, read_exons)
+        assert expected == c.extra_exon_percentage(isoform_region, read_exons)
 
 
 class TestExonFunctions:
@@ -126,21 +126,21 @@ class TestExonFunctions:
                              [([(1, 100)], []),
                               ([(1, 20), (41, 50), (61, 70)], [(21, 40), (51, 60)])])
     def test_junctions_from_blocks(self, exons, expected):
-        assert expected == junctions_from_blocks(exons)
+        assert expected == c.junctions_from_blocks(exons)
 
     @pytest.mark.parametrize("region, introns, intron_position, expected",
                              [((0, 100), [(20, 80)], 0, (81, 100)),
                               ((0, 100), [(20, 40), (60, 80)], 0, (41, 59)),
                               ((0, 100), [(20, 40), (60, 80)], 1, (81, 100))])
     def test_following_exon(self, region, introns, intron_position, expected):
-        assert expected == get_following_exon_from_junctions(region, introns, intron_position)
+        assert expected == c.get_following_exon_from_junctions(region, introns, intron_position)
 
     @pytest.mark.parametrize("region, introns, intron_position, expected",
                              [((0, 100), [(20, 80)], 0, (0, 19)),
                               ((0, 100), [(20, 40), (60, 80)], 0, (0, 19)),
                               ((0, 100), [(20, 40), (60, 80)], 1, (41, 59))])
     def test_preceding_exon(self, region, introns, intron_position, expected):
-        assert expected == get_preceding_exon_from_junctions(region, introns, intron_position)
+        assert expected == c.get_preceding_exon_from_junctions(region, introns, intron_position)
 
     @pytest.mark.parametrize("region, introns, exon_position, expected",
                              [((0, 100), [(20, 80)], 0, (0, 19)),
@@ -149,13 +149,13 @@ class TestExonFunctions:
                               ((0, 100), [(20, 40), (60, 80)], 1, (41, 59)),
                               ((0, 100), [(20, 40), (60, 80)], 2, (81, 100))])
     def test_get_exon(self, region, introns, exon_position, expected):
-        assert expected == get_exon(region, introns, exon_position)
+        assert expected == c.get_exon(region, introns, exon_position)
 
     @pytest.mark.parametrize("exons, expected",
                              [([(1, 100)], [(2, 100)]),
                               ([(1, 20), (41, 50), (61, 70)], [(2, 20), (42, 50), (62, 70)])])
     def test_correct_bam_coords(self, exons, expected):
-        assert expected == correct_bam_coords(exons)
+        assert expected == c.correct_bam_coords(exons)
 
     @pytest.mark.parametrize("exons, cigar_tuples, expected",
                              [([(1, 100)], [(0, 99)], [(1, 100)]),
@@ -163,7 +163,7 @@ class TestExonFunctions:
                                [(4, 10), (0, 10), (1, 2), (0, 10), (3, 11), (0, 9), (2, 1), (0, 9), (2, 1), (0, 9), (2, 2), (0, 8), (3, 20), (0, 10), (1, 3), (0, 4),  (2, 3), (0, 3), (5, 10)],
                                [(10, 30), (41, 80), (100, 120)])])
     def test_concat(self, exons, cigar_tuples, expected):
-        assert expected == concat_gapless_blocks(exons, cigar_tuples)
+        assert expected == c.concat_gapless_blocks(exons, cigar_tuples)
 
 
 class TestProfiles:
@@ -172,14 +172,14 @@ class TestProfiles:
                                                               ([-2, 1, -1, -2], [-1, 1, 1, 1], False),
                                                               ([-2, 1, -1, -2], [-1, 1, -1, 1], True)])
     def test_is_subprofile(self, profile1, profile2, expected):
-        assert expected == is_subprofile(profile1, profile2)
+        assert expected == c.is_subprofile(profile1, profile2)
 
     @pytest.mark.parametrize("profile1, profile2, expected", [([], [], 0), ([0], [1], 0), ([1], [1], 0),
                                                               ([1, -1], [1, 1], 1),
                                                               ([0], [0], 0), ([0, 1], [1, 1], 0),
                                                               ([-1, 1], [1, 0], 1), ([1, 0, -1], [0, 1, 1], 1)])
     def test_difference_in_present_features(self, profile1, profile2, expected):
-        assert expected == difference_in_present_features(profile1, profile2)
+        assert expected == c.difference_in_present_features(profile1, profile2)
 
     @pytest.mark.parametrize("profile1, profile2, profile_range, expected",
                              [([], [], None, 0), ([0], [1], (0, 1), 0), ([1], [1], (0, 1), 0),
@@ -187,75 +187,75 @@ class TestProfiles:
                               ([0], [0], (0, 1), 0), ([0, 1], [1, 1], (0, 1), 0),
                               ([-1, 1], [1, 0], (0, 1), 1), ([1, 0, -1], [0, 1, 1], (2, 3), 1)])
     def test_difference_in_present_features_with_range(self, profile1, profile2, profile_range, expected):
-        assert expected == difference_in_present_features(profile1, profile2, profile_range=profile_range)
+        assert expected == c.difference_in_present_features(profile1, profile2, profile_range=profile_range)
 
     @pytest.mark.parametrize("profile1, profile2, diff_limit, expected",
                              [([1, -1, -1], [-1, 1, 1], 0, 1)])
     def test_difference_in_present_features_with_lim(self, profile1, profile2, diff_limit, expected):
-        assert expected == difference_in_present_features(profile1, profile2, diff_limit=diff_limit)
+        assert expected == c.difference_in_present_features(profile1, profile2, diff_limit=diff_limit)
 
     @pytest.mark.parametrize("profile1, profile2, expected", [([0], [1], 0), ([0, 1], [1, 1], 1),
                                                               ([0, 1], [1, -2], 0), ([0, 1, -1], [-2, 1, 1], 1)])
     def test_count_both_present_features(self, profile1, profile2, expected):
-        assert expected == count_both_present_features(profile1, profile2)
+        assert expected == c.count_both_present_features(profile1, profile2)
 
     @pytest.mark.parametrize("profile1, profile2, expected", [([1], [1], True), ([1, 1], [0, 1], False),
                                                               ([-1, 1, 1, -2], [0, 1, 1, -2], True),
                                                               ([-2, 1, 1], [0, 1, -1], False)])
     def test_all_features_present(self, profile1, profile2, expected):
-        assert expected == all_features_present(profile1, profile2)
+        assert expected == c.all_features_present(profile1, profile2)
 
     @pytest.mark.parametrize("profile1, profile2, expected", [([1], [1], [1]), ([0, 1], [1, 1], [0, 1]),
                                                               ([0, 1, 1, 0], [-1, 1, 1, -2], [0, 1, 1, 0]),
                                                               ([0, 1, -1], [-2, 1, 1], [0, 1, 0])])
     def test_find_matching_positions(self, profile1, profile2, expected):
-        assert expected == find_matching_positions(profile1, profile2)
+        assert expected == c.find_matching_positions(profile1, profile2)
 
     @pytest.mark.parametrize("profile1, profile2, expected", [([1], [1], True), ([0, 1], [1, 1], True),
                                                               ([0, 1, 1, 0], [-1, 1, 1, -2], True),
                                                               ([1, -1, 0, 0], [-1, 1, 1, -2], False),
                                                               ([0, 1, -1], [-2, 1, 1], True)])
     def test_has_overlapping_features(self, profile1, profile2, expected):
-        assert expected == has_overlapping_features(profile1, profile2)
+        assert expected == c.has_overlapping_features(profile1, profile2)
 
     @pytest.mark.parametrize("profile1, profile2, expected", [([1], [1], False), ([0, 1], [1, 1], False),
                                                               ([0, 1, 1, 0], [-1, 1, 1, -2], False),
                                                               ([1, -1, 0, 0], [-1, 1, 1, -2], True),
                                                               ([0, 1, -1], [-2, 1, 1], True)])
     def test_has_inconsistent_features(self, profile1, profile2, expected):
-        assert expected == has_inconsistent_features(profile1, profile2)
+        assert expected == c.has_inconsistent_features(profile1, profile2)
 
     @pytest.mark.parametrize("profile1, mask, expected", [([1], [1], [1]), ([0, 1], [1, 1], [0, 1]),
                                                               ([0, 1, 1, 0], [1, 1, 0, 0], [0, 1, 0, 0]),
                                                               ([-2, -1, 1, 0], [1, 1, 0, 1], [-2, -1, 0, 0])])
     def test_mask_profile(self, profile1, mask, expected):
-        assert expected == mask_profile(profile1, mask)
+        assert expected == c.mask_profile(profile1, mask)
 
     @pytest.mark.parametrize("profile1, features, expected", [([1], [(10, 20)], [(10, 20)]), ([0, 1], [(10, 20), (30, 40)], [(30, 40)]),
                                                               ([0, 1, 0, 1], [(10, 20), (30, 40), (110, 120), (130, 140)], [(30, 40), (130, 140)])])
     def test_get_blocks_from_profile(self, profile1, features, expected):
-        assert expected == get_blocks_from_profile(features, profile1)
+        assert expected == c.get_blocks_from_profile(features, profile1)
 
     @pytest.mark.parametrize("profile1, profile2, expected", [([1], [1], False), ([0, 1], [1, 1], True),
                                                               ([0, 1, 1, 0], [-1, 1, 1, -2], False),
                                                               ([-1, -1, 1, 0], [-1, 1, 1, -2], True),
                                                               ([0, 1, -1], [-2, 1, 1], False)])
     def test_left_truncated(self, profile1, profile2, expected):
-        assert expected == left_truncated(profile1, profile2)
+        assert expected == c.left_truncated(profile1, profile2)
 
     @pytest.mark.parametrize("profile1, profile2, expected", [([1], [1], False), ([1, 0], [1, 1], True),
                                                               ([0, 1, 1, 0], [-1, 1, 1, -2], False),
                                                               ([-1, 1, -1, 0], [-1, 1, 1, -2], True),
                                                               ([0, 1, -1], [-2, 1, 1], True)])
     def test_right_truncated(self, profile1, profile2, expected):
-        assert expected == right_truncated(profile1, profile2)
+        assert expected == c.right_truncated(profile1, profile2)
 
 
 class TestListToStr:
     def test_empty(self):
-        assert "." == list_to_str([])
+        assert "." == c.list_to_str([])
 
     @pytest.mark.parametrize("element_list, sep, expected", [([1], ",", "1"), ([1, 0, 2], ":", "1:0:2")])
     def test_not_empty(self, element_list, sep, expected):
-        assert expected == list_to_str(element_list, sep)
+        assert expected == c.list_to_str(element_list, sep)
 

--- a/tests/test_gene_info.py
+++ b/tests/test_gene_info.py
@@ -1,5 +1,6 @@
 import gffutils
-from src.gene_info import *
+import os
+from src.gene_info import GeneInfo
 
 
 class TestGeneInfo:

--- a/tests/test_gene_info.py
+++ b/tests/test_gene_info.py
@@ -1,4 +1,3 @@
-import pytest
 import gffutils
 from src.gene_info import *
 

--- a/tests/test_long_read_assigner.py
+++ b/tests/test_long_read_assigner.py
@@ -1,4 +1,4 @@
-from collections import namedtuple, Counter
+from collections import namedtuple
 
 import pytest
 import gffutils

--- a/tests/test_long_read_assigner.py
+++ b/tests/test_long_read_assigner.py
@@ -9,11 +9,13 @@ from src.common import equal_ranges, overlaps_at_least
 from src.isoform_assignment import MatchEventSubtype, ReadAssignmentType
 from src.long_read_assigner import (
     AmbiguityResolvingMethod,
-    CombinedReadProfiles,
     IsoformDiff,
     LongReadAssigner,
-    MappedReadProfile,
+)
+from src.long_read_profiles import (
+    CombinedReadProfiles,
     OverlappingFeaturesProfileConstructor,
+    MappedReadProfile,
     NonOverlappingFeaturesProfileConstructor,
 )
 from src.gene_info import GeneInfo

--- a/tests/test_long_read_assigner.py
+++ b/tests/test_long_read_assigner.py
@@ -3,9 +3,20 @@ from collections import namedtuple
 import pytest
 import gffutils
 import os
+from functools import partial
 
-from src.long_read_assigner import *
-from src.gene_info import *
+from src.common import equal_ranges, overlaps_at_least
+from src.isoform_assignment import MatchEventSubtype, ReadAssignmentType
+from src.long_read_assigner import (
+    AmbiguityResolvingMethod,
+    CombinedReadProfiles,
+    IsoformDiff,
+    LongReadAssigner,
+    MappedReadProfile,
+    OverlappingFeaturesProfileConstructor,
+    NonOverlappingFeaturesProfileConstructor,
+)
+from src.gene_info import GeneInfo
 from src.polya_finder import PolyAInfo
 
 

--- a/tests/test_long_read_profile.py
+++ b/tests/test_long_read_profile.py
@@ -1,6 +1,11 @@
 import pytest
+from functools import partial
 
-from src.long_read_profiles import *
+from src.common import equal_ranges, overlaps_at_least
+from src.long_read_profiles import (
+    OverlappingFeaturesProfileConstructor,
+    NonOverlappingFeaturesProfileConstructor,
+)
 
 
 class TestOverlappingFeatureProfile:

--- a/tests/test_polya_cage_finder.py
+++ b/tests/test_polya_cage_finder.py
@@ -1,5 +1,5 @@
 import os
-from collections import namedtuple, Counter
+from collections import namedtuple
 
 import pytest
 


### PR DESCRIPTION
This PR touches a lot of files but it's just cleaning up the imports in a few ways:

 - Removed unused imports
 - I removed all instances `from module import *` and replaced them with explicit imports (in the `src/` directory only, I didn't touch `misc/` for this). There were a lot of tangled imports in the code (e.g. X imported something from Y, but it was actually defined in Z and imported by Y) which can eventually lead to a mess of circular imports and annoying bugs. This is also the first step to better organization in the long run.
 - Changed `from src.module` to `from .module` for everything in the `src` package. This makes renaming the package a lot easier later (probably want to name it `isoquant` rather than `src`)

I successfully ran `isoquant.py --test` to verify that this is all still working, as best I can tell.