### PR TITLE
Refactor read groups

### DIFF
--- a/src/dataset_processor.py
+++ b/src/dataset_processor.py
@@ -362,8 +362,13 @@ class DatasetProcessor:
         logger.info("Sample has " + proper_plural_form("BAM file", len(sample.file_list)) + ": " + ", ".join(map(lambda x: x[0], sample.file_list)))
         self.args.use_technical_replicas = self.args.read_group == "file_name" and len(sample.file_list) > 1
         self.multimapped_reads = defaultdict(list)
+
         self.all_read_groups = set()
-        prepare_read_groups(self.args, sample)
+        if self.args.resume and os.path.exists(sample.read_group_file + "_lock"):
+            logger.info("Read group table was split during the previous run, existing files will be used")
+        else:
+            prepare_read_groups(self.args, sample)
+            open(sample.read_group_file + "_lock", "w").close()
 
         if self.args.read_assignments:
             saves_file = self.args.read_assignments[0]

--- a/src/dataset_processor.py
+++ b/src/dataset_processor.py
@@ -37,7 +37,7 @@ from .long_read_counter import (
 from .multimap_resolver import MultimapResolver
 from .read_groups import (
     create_read_grouper,
-    DefaultReadGrouper
+    prepare_read_groups
 )
 from .assignment_io import (
     IOSupport,
@@ -71,7 +71,7 @@ def clean_locks(chr_ids, base_name, fname_function):
 
 
 def collect_reads_in_parallel(sample, chr_id, args, current_chr_record):
-    read_grouper = create_read_grouper(args) # add sample, chr_id
+    read_grouper = create_read_grouper(args, sample, chr_id)
     lock_file = reads_collected_lock_file_name(sample.out_raw_file, chr_id)
     save_file = "{}_{}".format(sample.out_raw_file, chr_id)
     group_file = "{}_{}_groups".format(sample.out_raw_file, chr_id)
@@ -363,6 +363,7 @@ class DatasetProcessor:
         self.args.use_technical_replicas = self.args.read_group == "file_name" and len(sample.file_list) > 1
         self.multimapped_reads = defaultdict(list)
         self.all_read_groups = set()
+        prepare_read_groups(self.args, sample)
 
         if self.args.read_assignments:
             saves_file = self.args.read_assignments[0]

--- a/src/gene_info.py
+++ b/src/gene_info.py
@@ -17,6 +17,7 @@ from .common import (
     is_subprofile,
     overlaps,
     junctions_from_blocks,
+    AtomicCounter
 )
 
 logger = logging.getLogger('IsoQuant')
@@ -100,7 +101,9 @@ class FeatureProfiles:
 
 # exon/intron info
 class FeatureInfo:
+    feature_id_counter = AtomicCounter()
     def __init__(self, chr_id, start, end, strand, type, gene_ids):
+        self.id = FeatureInfo.feature_id_counter.increment()
         self.chr_id = chr_id
         self.start = start
         self.end = end

--- a/src/input_data_storage.py
+++ b/src/input_data_storage.py
@@ -28,8 +28,7 @@ class SampleData:
     def _init_paths(self):
         self.out_assigned_tsv = self._make_path(self.label + ".read_assignments.tsv")
         self.out_raw_file = self._make_aux_path(self.label + ".save")
-        # self.read_group_file = self._make_aux_path(self.label + ".read_group")
-        # self.out_mapped_bed = self._make_path(self.label + ".mapped_reads.bed")
+        self.read_group_file = self._make_aux_path(self.label + ".read_group")
         self.out_corrected_bed = self._make_path(self.label + ".corrected_reads.bed")
         self.out_alt_tsv = self._make_path(self.label + ".SQANTI-like.tsv")
         self.out_gene_counts_tsv = self._make_path(self.label + ".gene")

--- a/src/input_data_storage.py
+++ b/src/input_data_storage.py
@@ -28,6 +28,7 @@ class SampleData:
     def _init_paths(self):
         self.out_assigned_tsv = self._make_path(self.label + ".read_assignments.tsv")
         self.out_raw_file = self._make_aux_path(self.label + ".save")
+        # self.read_group_file = self._make_aux_path(self.label + ".read_group")
         # self.out_mapped_bed = self._make_path(self.label + ".mapped_reads.bed")
         self.out_corrected_bed = self._make_path(self.label + ".corrected_reads.bed")
         self.out_alt_tsv = self._make_path(self.label + ".SQANTI-like.tsv")

--- a/src/long_read_counter.py
+++ b/src/long_read_counter.py
@@ -123,12 +123,12 @@ class CompositeCounter:
 # count meta-features assigned to reads (genes or isoforms)
 # get_feature_id --- function that returns feature id form IsoformMatch object
 class AssignedFeatureCounter(AbstractCounter):
-    def __init__(self, output_prefix, get_feature_id, read_grouper, read_counter,
+    def __init__(self, output_prefix, get_feature_id, read_groups, read_counter,
                  ignore_read_groups=False, output_zeroes=True):
         AbstractCounter.__init__(self, output_prefix, ignore_read_groups, output_zeroes)
         self.get_feature_id = get_feature_id
         self.all_features = set()
-        self.all_groups = read_grouper.read_groups if read_grouper else []
+        self.all_groups = read_groups if read_groups else []
         self.read_counter = read_counter
 
         self.ambiguous_reads = 0
@@ -296,17 +296,17 @@ class AssignedFeatureCounter(AbstractCounter):
                         outf.write("%s\t%s\n" % (feature_id, "\t".join(["%.6f" % c for c in tpm_values])))
 
 
-def create_gene_counter(output_file_name, strategy, read_grouper=None, ignore_read_groups=False, output_zeroes=True):
+def create_gene_counter(output_file_name, strategy, read_groups=None, ignore_read_groups=False, output_zeroes=True):
     read_weight_counter = ReadWeightCounter(strategy, gene_counting=True)
     return AssignedFeatureCounter(output_file_name, get_assigned_gene_id,
-                                  read_grouper, read_weight_counter,
+                                  read_groups, read_weight_counter,
                                   ignore_read_groups, output_zeroes)
 
 
-def create_transcript_counter(output_file_name, strategy, read_grouper=None, ignore_read_groups=False, output_zeroes=True):
+def create_transcript_counter(output_file_name, strategy, read_groups=None, ignore_read_groups=False, output_zeroes=True):
     read_weight_counter = ReadWeightCounter(strategy, gene_counting=False)
     return AssignedFeatureCounter(output_file_name, get_assigned_transcript_id,
-                                  read_grouper, read_weight_counter,
+                                  read_groups, read_weight_counter,
                                   ignore_read_groups, output_zeroes)
 
 

--- a/src/long_read_counter.py
+++ b/src/long_read_counter.py
@@ -317,7 +317,7 @@ class ProfileFeatureCounter(AbstractCounter):
         # group_id -> (feature_id -> count)
         self.inclusion_feature_counter = defaultdict(lambda: defaultdict(int))
         self.exclusion_feature_counter = defaultdict(lambda: defaultdict(int))
-        self.feature_name_dict = OrderedDict(str)
+        self.feature_name_dict = OrderedDict()
         self.print_zeroes = print_zeroes
 
     def add_read_info_from_profile(self, gene_feature_profile, feature_property_map,
@@ -343,10 +343,11 @@ class ProfileFeatureCounter(AbstractCounter):
 
             for feature_id in self.feature_name_dict.keys():
                 for group_id in all_groups:
+                    feature_name = self.feature_name_dict[feature_id]
                     incl_count = self.inclusion_feature_counter[group_id][feature_id]
                     excl_count = self.exclusion_feature_counter[group_id][feature_id]
                     if self.print_zeroes or incl_count > 0 or excl_count > 0:
-                        f.write("%s\t%s\t%d\t%d\n" % (feature_id, group_id, incl_count, excl_count))
+                        f.write("%s\t%s\t%d\t%d\n" % (feature_name, group_id, incl_count, excl_count))
 
     def convert_counts_to_tpm(self):
         return


### PR DESCRIPTION
- Split large TSV files by chromosomes (reduces RAM consumption)
- Improve grouped exon counting structure
- Factor out all counter logic into a seprate class, get rid of ugly DatasetProcessor multiple usage