### PR TITLE
Keep cigartuples

### DIFF
--- a/src/alignment_processor.py
+++ b/src/alignment_processor.py
@@ -358,6 +358,7 @@ class AlignmentCollector:
             read_assignment.polya_info = alignment_info.polya_info
             read_assignment.cage_found = len(alignment_info.cage_hits) > 0
             read_assignment.exons = alignment_info.read_exons
+            read_assignment.cigartuples = alignment.cigartuples
             read_assignment.corrected_exons = exon_corrector.correct_assigned_read(alignment_info,
                                                                                    read_assignment)
             read_assignment.corrected_introns = junctions_from_blocks(read_assignment.corrected_exons)

--- a/src/alignment_processor.py
+++ b/src/alignment_processor.py
@@ -307,6 +307,7 @@ class AlignmentCollector:
             read_assignment.polya_info = alignment_info.polya_info
             read_assignment.cage_found = len(alignment_info.cage_hits) > 0
             read_assignment.exons = alignment_info.read_exons
+            read_assignment.cigartuples = alignment.cigartuples
             read_assignment.corrected_exons = alignment_info.read_exons
             read_assignment.corrected_introns = junctions_from_blocks(read_assignment.corrected_exons)
 

--- a/src/graph_based_model_construction.py
+++ b/src/graph_based_model_construction.py
@@ -267,7 +267,7 @@ class GraphBasedModelConstructor:
             corrected_exons,
             exons
         )
-        logger.debug("Corrected exons: ", updated_exons)
+        logger.debug(f"Corrected exons: {len(updated_exons)}, {updated_exons}")
         
         return updated_exons
 

--- a/src/graph_based_model_construction.py
+++ b/src/graph_based_model_construction.py
@@ -251,6 +251,7 @@ class GraphBasedModelConstructor:
             splice_site_cases,
             MIN_N_OF_ALIGNED_READS,
             ACCEPTED_DEL_CASES,
+            THRESHOLD_CASES_AT_LOCATION,
             MORE_CONSERVATIVE_STRATEGY,
             strand,
             self.chr_record

--- a/src/graph_based_model_construction.py
+++ b/src/graph_based_model_construction.py
@@ -265,6 +265,7 @@ class GraphBasedModelConstructor:
             corrected_exons,
             exons
         )
+        logger.debug("Corrected exons: ", updated_exons)
         
         return updated_exons
 

--- a/src/graph_based_model_construction.py
+++ b/src/graph_based_model_construction.py
@@ -213,7 +213,7 @@ class GraphBasedModelConstructor:
                 if read.cigartuples:
                     found_cigartuples = True
                     break
-            logger.debug(f"Heidi: Method correct_transcripts. Transcript: {model.transcript_id}, four one or more cigartuples: {found_cigartuples}")    
+            logger.debug(f"Heidi: Method correct_transcripts. Transcript: {model.transcript_id}, found one or more cigartuples: {found_cigartuples}")    
             corrected_exons = self.correct_transcript_splice_sites(exons, assigned_reads)
             if corrected_exons:
                 model.exon_blocks = corrected_exons

--- a/src/graph_based_model_construction.py
+++ b/src/graph_based_model_construction.py
@@ -208,15 +208,9 @@ class GraphBasedModelConstructor:
         for model in self.transcript_model_storage:
             exons = model.exon_blocks
             assigned_reads = self.transcript_read_ids[model.transcript_id]
-            found_cigartuples = False
-            # TODO: REMOVE NEXT FIVE LINES AFTER CIAGRTUPLES ARE FIXED
-            for read in assigned_reads:
-                if read.cigartuples:
-                    found_cigartuples = True
-                    break
-            logger.debug(f"Heidi: Method correct_transcripts. Transcript: {model.transcript_id}, found one or more cigartuples: {found_cigartuples}")    
             corrected_exons = self.correct_transcript_splice_sites(exons, assigned_reads)
             if corrected_exons:
+                logger.debug(f"correct_transcripts. Corrected exons: {corrected_exons}, original exons: {exons}")
                 model.exon_blocks = corrected_exons
 
     def correct_transcript_splice_sites(self, exons: list, assigned_reads: list):
@@ -237,7 +231,6 @@ class GraphBasedModelConstructor:
 
 
         strand = assigned_reads[0].strand
-        logger.debug(f"correct_transcript_splice_sites. Correcting splice sites. n of exons: {len(exons)}, n of assigned reads: {len(assigned_reads)}, strand: {strand}")
         if strand not in SUPPORTED_STRANDS:
             return None
 
@@ -259,7 +252,7 @@ class GraphBasedModelConstructor:
                 splice_site_cases,
                 WINDOW_SIZE)
             
-        logger.debug(f"correct_transcript_splice_sites. Splice site cases: {splice_site_cases}")
+        
 
         corrected_exons = correct_splice_site_errors(
             splice_site_cases,
@@ -275,7 +268,6 @@ class GraphBasedModelConstructor:
             return None
         
         cases = [str(exon) + ": " + str(splice_site_cases[exon]) for exon in corrected_exons]
-        logger.debug(f"correct_transcript_splice_sites. Corrected exons: {len(corrected_exons)}, {corrected_exons} {cases}")
         
         
         updated_exons = generate_updated_exon_list(

--- a/src/graph_based_model_construction.py
+++ b/src/graph_based_model_construction.py
@@ -208,6 +208,15 @@ class GraphBasedModelConstructor:
         for model in self.transcript_model_storage:
             exons = model.exon_blocks
             assigned_reads = self.transcript_read_ids[model.transcript_id]
+            cigartuples = False
+            for read in assigned_reads:
+                if read.cigartuples:
+                    cigartuples = True
+                    break
+            if not cigartuples:
+                logger.debug(f"Heidi: Method correct_transcripts. No cigar tuples for transcript {model.transcript_id}")    
+            else:
+                logger.debug(f"Heidi: Method correct_transcripts. Yes cigar tuples for transcript {model.transcript_id}")
             corrected_exons = self.correct_transcript_splice_sites(exons, assigned_reads)
             if corrected_exons:
                 model.exon_blocks = corrected_exons
@@ -240,9 +249,9 @@ class GraphBasedModelConstructor:
             read_end = read_assignment.corrected_exons[-1][1]
             cigartuples = read_assignment.cigartuples
             if not cigartuples:
-                logger.debug(f"Heidi: No cigar tuples for read {read_assignment.read_id}")
+                # logger.debug(f"Heidi: No cigar tuples for read {read_assignment.read_id}")
                 continue
-            logger.debug(f"Heidi: Cigar tuples for read {read_assignment.read_id}: {cigartuples}")
+            # logger.debug(f"Heidi: Cigar tuples for read {read_assignment.read_id}: {cigartuples}")
             count_deletions_for_splice_site_locations(
                 read_start, 
                 read_end, 

--- a/src/graph_based_model_construction.py
+++ b/src/graph_based_model_construction.py
@@ -240,6 +240,7 @@ class GraphBasedModelConstructor:
             read_end = read_assignment.corrected_exons[-1][1]
             cigartuples = read_assignment.cigartuples
             if not cigartuples:
+                logger.debug(f"Heidi: No cigar tuples for read {read_assignment.read_id}")
                 continue
             count_deletions_for_splice_site_locations(
                 read_start, 

--- a/src/graph_based_model_construction.py
+++ b/src/graph_based_model_construction.py
@@ -130,6 +130,7 @@ class GraphBasedModelConstructor:
         self.construct_assignment_based_isoforms(read_assignment_storage)
         self.assign_reads_to_models(read_assignment_storage)
         self.filter_transcripts()
+        self.correct_transcripts()
 
         if self.params.genedb:
             self.create_extended_annotation()
@@ -197,6 +198,23 @@ class GraphBasedModelConstructor:
             model.add_additional_attribute("similar_reference_id", assigned_transcript_id)
             model.add_additional_attribute("alternatives", event_string)
             self.transcript2transcript.append(assignment)
+
+    def correct_transcripts(self):
+        for model in self.transcript_model_storage:
+            exons = model.exon_blocks
+            assigned_reads = self.transcript_read_ids[model.transcript_id]
+            corrected_exons = self.correct_transcript_splice_sites(exons, assigned_reads)
+            if corrected_exons:
+                model.exon_blocks = corrected_exons
+
+    def correct_transcript_splice_sites(self, exons, assigned_reads):
+        # exons: list of coordinate pairs
+        # assigned_reads: list of ReadAssignment, contains read_id and cigartuples
+        # self.chr_record - FASTA recored, i.e. a single chromosome from a reference
+        # returns: a list of corrected exons if correction takes place, None - otherwise
+        # TODO Heidi: insert your code here
+        return None
+
 
     def filter_transcripts(self):
         filtered_storage = []

--- a/src/graph_based_model_construction.py
+++ b/src/graph_based_model_construction.py
@@ -269,17 +269,17 @@ class GraphBasedModelConstructor:
         if not corrected_exons:
             return None
         
-        corrected_exons = []
+        final_corrected_exons = []
         for exon in exons:
-            corrected_exon = exon
+            new_corrected_exon = exon
             if exon[0] in splice_site_cases:
                 corrected_location = exon[0] + splice_site_cases[exon[0]]["most_common_del"]
                 corrected_exon = (corrected_location, exon[1])
             if exon[1] in splice_site_cases:
                 corrected_location = exon[1] + splice_site_cases[exon[1]]["most_common_del"]
                 corrected_exon = (exon[0], corrected_location)
-            corrected_exons.append(corrected_exon)
-        return corrected_exons
+            final_corrected_exons.append(new_corrected_exon)
+        return final_corrected_exons
 
 
     def filter_transcripts(self):

--- a/src/graph_based_model_construction.py
+++ b/src/graph_based_model_construction.py
@@ -219,7 +219,7 @@ class GraphBasedModelConstructor:
         # returns: a list of corrected exons if correction takes place, None - otherwise
         # TODO Heidi: insert your code here
 
-        
+        logger.debug("Correcting splice sites. n of exons: ", len(exons), " n of assigned reads: ", len(assigned_reads))
         # Constants
         ACCEPTED_DEL_CASES = [3, 4, 5, 6]
         SUPPORTED_STRANDS = ['+', '-']

--- a/src/graph_based_model_construction.py
+++ b/src/graph_based_model_construction.py
@@ -231,6 +231,7 @@ class GraphBasedModelConstructor:
         SUPPORTED_STRANDS = ['+', '-']
         THRESHOLD_CASES_AT_LOCATION = 0.7
         MIN_N_OF_ALIGNED_READS = 5
+        WINDOW_SIZE = 8
 
         MORE_CONSERVATIVE_STRATEGY = False
 
@@ -255,7 +256,8 @@ class GraphBasedModelConstructor:
                 read_end, 
                 cigartuples, 
                 exons, 
-                splice_site_cases)
+                splice_site_cases,
+                WINDOW_SIZE)
             
         logger.debug(f"correct_transcript_splice_sites. Splice site cases: {splice_site_cases}")
 

--- a/src/graph_based_model_construction.py
+++ b/src/graph_based_model_construction.py
@@ -209,6 +209,7 @@ class GraphBasedModelConstructor:
             exons = model.exon_blocks
             assigned_reads = self.transcript_read_ids[model.transcript_id]
             found_cigartuples = False
+            # TODO: REMOVE NEXT FIVE LINES AFTER CIAGRTUPLES ARE FIXED
             for read in assigned_reads:
                 if read.cigartuples:
                     found_cigartuples = True

--- a/src/graph_based_model_construction.py
+++ b/src/graph_based_model_construction.py
@@ -236,7 +236,7 @@ class GraphBasedModelConstructor:
 
 
         strand = assigned_reads[0].strand
-        logger.debug(f"Heidi: Correcting splice sites. n of exons: {len(exons)}, n of assigned reads: {len(assigned_reads)}, strand: {strand}")
+        logger.debug(f"correct_transcript_splice_sites. Correcting splice sites. n of exons: {len(exons)}, n of assigned reads: {len(assigned_reads)}, strand: {strand}")
         if strand not in SUPPORTED_STRANDS:
             return None
 
@@ -257,7 +257,7 @@ class GraphBasedModelConstructor:
                 exons, 
                 splice_site_cases)
             
-        logger.debug(f"Heidi: Splice site cases: {splice_site_cases}")
+        logger.debug(f"correct_transcript_splice_sites. Splice site cases: {splice_site_cases}")
 
         corrected_exons = correct_splice_site_errors(
             splice_site_cases,
@@ -272,12 +272,15 @@ class GraphBasedModelConstructor:
         if not corrected_exons:
             return None
         
+        cases = [str(exon) + ": " + str(splice_site_cases[exon]) for exon in corrected_exons]
+        logger.debug(f"correct_transcript_splice_sites. Corrected exons: {len(corrected_exons)}, {corrected_exons} {cases}")
+        
+        
         updated_exons = generate_updated_exon_list(
             splice_site_cases,
             corrected_exons,
             exons
         )
-        logger.debug(f"Heidi: Corrected exons: {len(updated_exons)}, {updated_exons}")
         
         return updated_exons
 

--- a/src/graph_based_model_construction.py
+++ b/src/graph_based_model_construction.py
@@ -219,7 +219,6 @@ class GraphBasedModelConstructor:
         # returns: a list of corrected exons if correction takes place, None - otherwise
         # TODO Heidi: insert your code here
 
-        logger.debug(f"Correcting splice sites. n of exons: {len(exons)}, n of assigned reads: {len(assigned_reads)}")
         # Constants
         ACCEPTED_DEL_CASES = [3, 4, 5, 6]
         SUPPORTED_STRANDS = ['+', '-']
@@ -230,6 +229,7 @@ class GraphBasedModelConstructor:
 
 
         strand = assigned_reads[0].strand
+        logger.debug(f"Heidi: Correcting splice sites. n of exons: {len(exons)}, n of assigned reads: {len(assigned_reads)}, strand: {strand}")
         if strand not in SUPPORTED_STRANDS:
             return None
 
@@ -248,7 +248,8 @@ class GraphBasedModelConstructor:
                 exons, 
                 splice_site_cases)
 
-        
+        logger.debug(f"Heidi: Splice site cases: {splice_site_cases}")
+
         corrected_exons = correct_splice_site_errors(
             splice_site_cases,
             MIN_N_OF_ALIGNED_READS,
@@ -267,7 +268,7 @@ class GraphBasedModelConstructor:
             corrected_exons,
             exons
         )
-        logger.debug(f"Corrected exons: {len(updated_exons)}, {updated_exons}")
+        logger.debug(f"Heidi: Corrected exons: {len(updated_exons)}, {updated_exons}")
         
         return updated_exons
 

--- a/src/graph_based_model_construction.py
+++ b/src/graph_based_model_construction.py
@@ -208,12 +208,12 @@ class GraphBasedModelConstructor:
         for model in self.transcript_model_storage:
             exons = model.exon_blocks
             assigned_reads = self.transcript_read_ids[model.transcript_id]
-            cigartuples = False
+            found_cigartuples = False
             for read in assigned_reads:
                 if read.cigartuples:
-                    cigartuples = True
+                    found_cigartuples = True
                     break
-            logger.debug(f"Heidi: Method correct_transcripts. Transcript: {model.transcript_id}, four one or more cigartuples: {cigartuples}")    
+            logger.debug(f"Heidi: Method correct_transcripts. Transcript: {model.transcript_id}, four one or more cigartuples: {found_cigartuples}")    
             corrected_exons = self.correct_transcript_splice_sites(exons, assigned_reads)
             if corrected_exons:
                 model.exon_blocks = corrected_exons

--- a/src/graph_based_model_construction.py
+++ b/src/graph_based_model_construction.py
@@ -219,7 +219,7 @@ class GraphBasedModelConstructor:
         # returns: a list of corrected exons if correction takes place, None - otherwise
         # TODO Heidi: insert your code here
 
-        logger.debug("Correcting splice sites. n of exons: ", len(exons), " n of assigned reads: ", len(assigned_reads))
+        logger.debug(f"Correcting splice sites. n of exons: {len(exons)}, n of assigned reads: {len(assigned_reads)}")
         # Constants
         ACCEPTED_DEL_CASES = [3, 4, 5, 6]
         SUPPORTED_STRANDS = ['+', '-']

--- a/src/graph_based_model_construction.py
+++ b/src/graph_based_model_construction.py
@@ -242,13 +242,14 @@ class GraphBasedModelConstructor:
             if not cigartuples:
                 logger.debug(f"Heidi: No cigar tuples for read {read_assignment.read_id}")
                 continue
+            logger.debug(f"Heidi: Cigar tuples for read {read_assignment.read_id}: {cigartuples}")
             count_deletions_for_splice_site_locations(
                 read_start, 
                 read_end, 
                 cigartuples, 
                 exons, 
                 splice_site_cases)
-
+            
         logger.debug(f"Heidi: Splice site cases: {splice_site_cases}")
 
         corrected_exons = correct_splice_site_errors(

--- a/src/graph_based_model_construction.py
+++ b/src/graph_based_model_construction.py
@@ -239,6 +239,8 @@ class GraphBasedModelConstructor:
             read_start = read_assignment.corrected_exons[0][0]
             read_end = read_assignment.corrected_exons[-1][1]
             cigartuples = read_assignment.cigartuples
+            if not cigartuples:
+                continue
             count_deletions_for_splice_site_locations(
                 read_start, 
                 read_end, 

--- a/src/graph_based_model_construction.py
+++ b/src/graph_based_model_construction.py
@@ -213,10 +213,7 @@ class GraphBasedModelConstructor:
                 if read.cigartuples:
                     cigartuples = True
                     break
-            if not cigartuples:
-                logger.debug(f"Heidi: Method correct_transcripts. No cigar tuples for transcript {model.transcript_id}")    
-            else:
-                logger.debug(f"Heidi: Method correct_transcripts. Yes cigar tuples for transcript {model.transcript_id}")
+            logger.debug(f"Heidi: Method correct_transcripts. Transcript: {model.transcript_id}, four one or more cigartuples: {cigartuples}")    
             corrected_exons = self.correct_transcript_splice_sites(exons, assigned_reads)
             if corrected_exons:
                 model.exon_blocks = corrected_exons

--- a/src/isoform_assignment.py
+++ b/src/isoform_assignment.py
@@ -509,6 +509,8 @@ class ReadAssignment:
         read_assignment.read_id = read_string(infile)
         read_assignment.exons = read_list_of_pairs(infile, read_int)
         read_assignment.cigartuples = read_list_of_pairs(infile, read_int)
+        if not read_assignment.cigartuples:
+            read_assignment.cigartuples = None
         read_assignment.corrected_exons = read_list_of_pairs(infile, read_int)
         read_assignment.corrected_introns = junctions_from_blocks(read_assignment.corrected_exons)
         read_assignment.gene_info = gene_info
@@ -534,7 +536,10 @@ class ReadAssignment:
         write_int(self.assignment_id, outfile)
         write_string(self.read_id, outfile)
         write_list_of_pairs(self.exons, outfile, write_int)
-        write_list_of_pairs(self.cigartuples, outfile, write_int)
+        if self.cigartuples is None:
+            write_list_of_pairs([], outfile, write_int)
+        else:
+            write_list_of_pairs(self.cigartuples, outfile, write_int)
         write_list_of_pairs(self.corrected_exons, outfile, write_int)
         write_bool_array([self.multimapper, self.polyA_found, self.cage_found], outfile)
         write_int_neg(self.polya_info.external_polya_pos, outfile)

--- a/src/isoform_assignment.py
+++ b/src/isoform_assignment.py
@@ -477,6 +477,7 @@ class ReadAssignment:
         self.assignment_id = ReadAssignment.assignment_id_generator.increment()
         self.read_id = read_id
         self.exons = None
+        self.cigartuples = None
         self.corrected_exons = None
         self.corrected_introns = None
         self.gene_info = None
@@ -507,6 +508,7 @@ class ReadAssignment:
         read_assignment.assignment_id = read_int(infile)
         read_assignment.read_id = read_string(infile)
         read_assignment.exons = read_list_of_pairs(infile, read_int)
+        read_assignment.cigartuples = read_list_of_pairs(infile, read_int)
         read_assignment.corrected_exons = read_list_of_pairs(infile, read_int)
         read_assignment.corrected_introns = junctions_from_blocks(read_assignment.corrected_exons)
         read_assignment.gene_info = gene_info
@@ -532,6 +534,7 @@ class ReadAssignment:
         write_int(self.assignment_id, outfile)
         write_string(self.read_id, outfile)
         write_list_of_pairs(self.exons, outfile, write_int)
+        write_list_of_pairs(self.cigartuples, outfile, write_int)
         write_list_of_pairs(self.corrected_exons, outfile, write_int)
         write_bool_array([self.multimapper, self.polyA_found, self.cage_found], outfile)
         write_int_neg(self.polya_info.external_polya_pos, outfile)

--- a/src/transcript_splice_site_corrector.py
+++ b/src/transcript_splice_site_corrector.py
@@ -1,0 +1,241 @@
+def extract_location_from_cigar_string(cigartuples: list,
+                                    read_start: int,
+                                    read_end: int,
+                                    splice_site_location: int):
+    """
+    Extract location from cigar string.
+
+    Args:
+        cigar_tuples (list): list of cigar tuples (cigar code, aligned position).
+        See pysam documentation for more information
+        read_start (int): the start location for the read (base-1)
+        read_end (int): the end location for the read (base-1)
+        splice_site_location (int): location of interest (base-1)
+
+    Returns:
+        _type_: _description_
+    """
+    relative_position = splice_site_location - read_start
+    alignment_position = 0
+    ref_position = 0
+
+    for cigar_code in cigartuples:
+
+        if cigar_code[0] in [0, 2, 3, 7, 8]:
+            ref_position += cigar_code[1]
+        if ref_position <= relative_position and not \
+                read_start + ref_position == read_end:
+            alignment_position += cigar_code[1]
+        else:
+            return alignment_position + (cigar_code[1] - (ref_position - relative_position))
+
+    return -1
+
+
+def count_deletions_from_cigar_codes_in_given_window(cigartuples: list,
+                                                aligned_location: int,
+                                                location_is_end: bool,
+                                                splice_site_data: dict,
+                                                window_size: int):
+    """
+    Get cigar codes in a given window.
+
+    Args:
+        cigar_tuples (list): list of cigar tuples (cigar code, aligned position). See 
+        pysam documentation for more information
+        aligned_location (int): aligned location
+        loc_type (str): type of location (start or end)
+    """
+
+    deletions = 0
+    
+
+    cigar_code_list = []
+    location = 0
+
+    if location_is_end:
+        aligned_location = aligned_location - window_size + 1
+
+    for cigar_code in cigartuples:
+        if window_size == len(cigar_code_list):
+            break
+        if location + cigar_code[1] > aligned_location:
+            overlap = location + \
+                cigar_code[1] - (aligned_location + len(cigar_code_list))
+            cigar_code_list.extend(
+                [cigar_code[0] for _ in range(min(window_size -
+                                                len(cigar_code_list), overlap))])
+        location += cigar_code[1]
+
+    for i in range(window_size):
+        if i >= len(cigar_code_list):
+            break
+        if cigar_code_list[i] == 2:
+            deletions += 1
+            splice_site_data["del_pos_distr"][i] += 1
+    
+    if deletions not in splice_site_data:
+        splice_site_data["deletions"][deletions] = 0
+    
+    splice_site_data["deletions"][deletions] += 1
+
+
+def extract_splice_site_locations_within_aligned_read(read_start: int, read_end: int, exons:list):
+    matching_locations = []
+    for exon_start, exon_end in exons:
+        if read_start <= exon_start <= read_end:
+            location_is_end = False
+            matching_locations.append((exon_start, location_is_end))
+        if read_start <= exon_end <= read_end:
+            location_is_end = True
+            matching_locations.append((exon_end, location_is_end))
+        if read_end <= exon_end:
+            break
+    return matching_locations
+
+
+def count_deletions_for_splice_site_locations(assigned_read, exons: list, splice_site_cases: dict):
+    """
+
+    Args:
+        assigned_read (ReadAssignment): read assignment
+        exons (list): tuple of exons (start, end)
+        splice_site_cases (dict): a dictionary for storing splice site cases
+    """
+
+    # Extract read start and end
+    read_start = assigned_read.corrected_exons[0][0]
+    read_end = assigned_read.corrected_exons[-1][1]
+    cigartuples = assigned_read.cigartuples
+    
+    # Constant window size for counting deletions
+    WINDOW_SIZE = 8
+    
+    # Extract splice site locations within aligned read
+    matching_locations = extract_splice_site_locations_within_aligned_read(read_start, read_end, exons)
+    
+    # Count deletions for each splice site location
+    for splice_site_location, location_type in matching_locations:
+        if splice_site_location not in splice_site_cases:
+            splice_site_cases[splice_site_location] = {
+                'location_is_end': location_type,  
+                'deletions': {},
+                'del_pos_distr': [0 for _ in range(WINDOW_SIZE)],
+                'most_common_deletion': -1,
+                'del_location_has_canonical_nucleotides': False
+            }
+        
+        # Processing cigartuples
+        # 1. Find the aligned location
+        aligned_location = extract_location_from_cigar_string(cigartuples, read_start, read_end, splice_site_location)
+        # 2. Count deletions in a predefined window
+        count_deletions_from_cigar_codes_in_given_window(
+            cigartuples, 
+            aligned_location, 
+            location_type, 
+            splice_site_cases[splice_site_location], 
+            WINDOW_SIZE)
+
+
+
+def compute_most_common_case_of_deletions(deletions: dict, location_is_end: bool):
+    del_most_common_case = [k for k, v in deletions.items(
+    ) if v == max(deletions.values())]
+    if len(del_most_common_case) == 1:
+        if location_is_end:
+            return -del_most_common_case[0]
+        return del_most_common_case[0]
+    return -1    
+
+
+def extract_nucleotides_from_most_common_del_location(
+        location: int, 
+        splice_site_data: dict, 
+        chr_record, 
+        strand: str):
+    most_common_del = splice_site_data["most_common_del"]
+    idx_correction = -1
+    extraction_start = location + most_common_del + idx_correction
+    extraction_end = location + most_common_del + 2 + idx_correction
+    try:
+        extracted_canonicals =  chr_record[extraction_start:extraction_end]
+    except KeyError:
+        extracted_canonicals = 'XX'
+    
+    
+    canonical_pairs = {
+        '+': {
+            'start': ['AG', 'AC'],
+            'end': ['GT', 'GC', 'AT']
+        },
+        '-': {
+            'start': ['AC', 'GC', 'AC'],
+            'end': ['CT', 'GT']
+        }
+    }
+    if splice_site_data["location_is_end"]:
+        possible_canonicals = canonical_pairs[strand]['end']
+    else:
+        possible_canonicals = canonical_pairs[strand]['start']
+    
+    if extracted_canonicals in possible_canonicals:
+        splice_site_data["del_location_has_canonical_nucleotides"] = True
+
+def compute_most_common_del_and_verify_nucleotides(
+        splice_site_location: int, 
+        splice_site_data: dict, 
+        chr_record,
+        ACCEPTED_DEL_CASES: list,
+        strand: str,):
+    
+    
+    # Compute most common case of deletions
+    splice_site_data["most_common_deletion"] = compute_most_common_case_of_deletions(
+        splice_site_data["deletions"],
+        splice_site_data["location_is_end"])
+    
+    # Extract nucleotides from most common deletion location if it is an accepted case
+    if splice_site_data["most_common_deletion"] in ACCEPTED_DEL_CASES:
+        extract_nucleotides_from_most_common_del_location(
+            splice_site_location, 
+            splice_site_data, 
+            chr_record, 
+            strand)
+
+
+
+def threshold_exceeded(
+        del_pos_distr: list,
+        deletions: dict,
+        most_common_del: int,
+        THRESHOLD_CASES_AT_LOCATION):
+    total_cases = sum(deletions.values())
+    nucleotides_exceeding_treshold = 0
+    for value in del_pos_distr:
+        if value / total_cases > THRESHOLD_CASES_AT_LOCATION:
+            nucleotides_exceeding_treshold += 1
+    return bool(nucleotides_exceeding_treshold >= abs(most_common_del))
+
+def sublist_largest_values_exists(lst, n):
+    """
+        Verifies that there is a sublist of size n that contains the largest values in the list.
+        Not currently in use, but may be included in the error prediction strategy for stricter prediction. 
+    Args:
+        lst (int): list of deletion distribution
+        n (int): most common case of deletions
+
+    Returns:
+        _type_: _description_
+    """
+    largest_values = set(sorted(lst, reverse=True)[:n])
+    count = 0
+
+    for num in lst:
+        if num in largest_values:
+            count += 1
+            if count >= n:
+                return True
+        else:
+            count = 0
+
+    return False

--- a/src/transcript_splice_site_corrector.py
+++ b/src/transcript_splice_site_corrector.py
@@ -102,7 +102,8 @@ def count_deletions_for_splice_site_locations(
         read_end: int, 
         cigartuples: list, 
         exons: list, 
-        splice_site_cases: dict):
+        splice_site_cases: dict,
+        WINDOW_SIZE: int):
     """
 
     Args:
@@ -111,9 +112,6 @@ def count_deletions_for_splice_site_locations(
         splice_site_cases (dict): a dictionary for storing splice site cases
     """
 
-    
-    # Constant window size for counting deletions
-    WINDOW_SIZE = 8
     
     # Extract splice site locations within aligned read
     matching_locations = extract_splice_site_locations_within_aligned_read(read_start, read_end, exons)

--- a/src/transcript_splice_site_corrector.py
+++ b/src/transcript_splice_site_corrector.py
@@ -157,7 +157,7 @@ def extract_nucleotides_from_most_common_del_location(
         chr_record, 
         strand: str):
     most_common_del = splice_site_data["most_common_del"]
-    idx_correction = -1
+    idx_correction = 0
     extraction_start = location + most_common_del + idx_correction
     extraction_end = location + most_common_del + 2 + idx_correction
     try:

--- a/src/transcript_splice_site_corrector.py
+++ b/src/transcript_splice_site_corrector.py
@@ -122,7 +122,7 @@ def count_deletions_for_splice_site_locations(
                 'location_is_end': location_type,  
                 'deletions': {},
                 'del_pos_distr': [0 for _ in range(WINDOW_SIZE)],
-                'most_common_deletion': -1,
+                'most_common_del': -1,
                 'del_location_has_canonical_nucleotides': False
             }
         
@@ -191,12 +191,12 @@ def compute_most_common_del_and_verify_nucleotides(
     
     
     # Compute most common case of deletions
-    splice_site_data["most_common_deletion"] = compute_most_common_case_of_deletions(
+    splice_site_data["most_common_del"] = compute_most_common_case_of_deletions(
         splice_site_data["deletions"],
         splice_site_data["location_is_end"])
     
     # Extract nucleotides from most common deletion location if it is an accepted case
-    if splice_site_data["most_common_deletion"] in ACCEPTED_DEL_CASES:
+    if splice_site_data["most_common_del"] in ACCEPTED_DEL_CASES:
         extract_nucleotides_from_most_common_del_location(
             splice_site_location, 
             splice_site_data, 

--- a/src/transcript_splice_site_corrector.py
+++ b/src/transcript_splice_site_corrector.py
@@ -1,3 +1,6 @@
+import logging
+logger = logging.getLogger('IsoQuant')
+
 def extract_location_from_cigar_string(cigartuples: list,
                                     read_start: int,
                                     read_end: int,
@@ -114,7 +117,7 @@ def count_deletions_for_splice_site_locations(
     
     # Extract splice site locations within aligned read
     matching_locations = extract_splice_site_locations_within_aligned_read(read_start, read_end, exons)
-    
+    logger.debug(f"Matching locations: {matching_locations}")
     # Count deletions for each splice site location
     for splice_site_location, location_type in matching_locations:
         if splice_site_location not in splice_site_cases:

--- a/src/transcript_splice_site_corrector.py
+++ b/src/transcript_splice_site_corrector.py
@@ -205,7 +205,7 @@ def compute_most_common_del_and_verify_nucleotides(
 
 
 
-def threshold_exceeded(
+def threshold_for_del_cases_exceeded(
         del_pos_distr: list,
         deletions: dict,
         most_common_del: int,
@@ -246,6 +246,7 @@ def correct_splice_site_errors(
         splice_site_cases: dict,
         MIN_N_OF_ALIGNED_READS: int,
         ACCEPTED_DEL_CASES: list,
+        THRESHOLD_CASES_AT_LOCATION: float,
         MORE_CONSERVATIVE_STRATEGY: bool,
         strand: str,
         chr_record):
@@ -281,7 +282,12 @@ def correct_splice_site_errors(
                 splice_site_data["del_pos_distr"],
                 abs(splice_site_data["most_common_del"])):
                 continue
-            pass
+            if not threshold_for_del_cases_exceeded(
+                splice_site_data["del_pos_distr"],
+                splice_site_data["deletions"],
+                splice_site_data["most_common_del"],
+                THRESHOLD_CASES_AT_LOCATION):
+                continue
 
         if splice_site_data["del_location_has_canonical_nucleotides"]:
             locations_with_errors.append(splice_site_location)

--- a/src/transcript_splice_site_corrector.py
+++ b/src/transcript_splice_site_corrector.py
@@ -214,7 +214,7 @@ def threshold_for_del_cases_exceeded(
     total_cases = sum(deletions.values())
     nucleotides_exceeding_treshold = 0
     for value in del_pos_distr:
-        if value / total_cases > THRESHOLD_CASES_AT_LOCATION:
+        if value  > total_cases * THRESHOLD_CASES_AT_LOCATION:
             nucleotides_exceeding_treshold += 1
     return bool(nucleotides_exceeding_treshold >= abs(most_common_del))
 

--- a/src/transcript_splice_site_corrector.py
+++ b/src/transcript_splice_site_corrector.py
@@ -182,7 +182,6 @@ def extract_nucleotides_from_most_common_del_location(
         possible_canonicals = canonical_pairs[strand]['end']
     else:
         possible_canonicals = canonical_pairs[strand]['start']
-    
     if extracted_canonicals in possible_canonicals:
         splice_site_data["del_location_has_canonical_nucleotides"] = True
 
@@ -200,7 +199,7 @@ def compute_most_common_del_and_verify_nucleotides(
         splice_site_data["location_is_end"])
     
     # Extract nucleotides from most common deletion location if it is an accepted case
-    if splice_site_data["most_common_del"] in ACCEPTED_DEL_CASES:
+    if abs(splice_site_data["most_common_del"]) in ACCEPTED_DEL_CASES:
         extract_nucleotides_from_most_common_del_location(
             splice_site_location, 
             splice_site_data, 

--- a/src/transcript_splice_site_corrector.py
+++ b/src/transcript_splice_site_corrector.py
@@ -125,7 +125,7 @@ def count_deletions_for_splice_site_locations(
                 'deletions': {},
                 'del_pos_distr': [0 for _ in range(WINDOW_SIZE)],
                 'most_common_del': -1,
-                'del_location_has_canonical_nucleotides': False
+                'canonical_bases_found': False
             }
         
         # Processing cigartuples
@@ -181,7 +181,7 @@ def extract_nucleotides_from_most_common_del_location(
     else:
         possible_canonicals = canonical_pairs[strand]['start']
     if extracted_canonicals in possible_canonicals:
-        splice_site_data["del_location_has_canonical_nucleotides"] = True
+        splice_site_data["canonical_bases_found"] = True
 
 def compute_most_common_del_and_verify_nucleotides(
         splice_site_location: int, 
@@ -292,7 +292,7 @@ def correct_splice_site_errors(
                 THRESHOLD_CASES_AT_LOCATION):
                 continue
 
-        if splice_site_data["del_location_has_canonical_nucleotides"]:
+        if splice_site_data["canonical_bases_found"]:
             locations_with_errors.append(splice_site_location)
     
     return locations_with_errors

--- a/src/transcript_splice_site_corrector.py
+++ b/src/transcript_splice_site_corrector.py
@@ -50,7 +50,7 @@ def count_deletions_from_cigar_codes_in_given_window(cigartuples: list,
         loc_type (str): type of location (start or end)
     """
 
-    deletions = 0
+    count_of_deletions = 0
     
 
     cigar_code_list = []
@@ -74,13 +74,13 @@ def count_deletions_from_cigar_codes_in_given_window(cigartuples: list,
         if i >= len(cigar_code_list):
             break
         if cigar_code_list[i] == 2:
-            deletions += 1
+            count_of_deletions += 1
             splice_site_data["del_pos_distr"][i] += 1
     
-    if deletions not in splice_site_data:
-        splice_site_data["deletions"][deletions] = 0
+    if count_of_deletions not in splice_site_data["deletions"]:
+        splice_site_data["deletions"][count_of_deletions] = 0
     
-    splice_site_data["deletions"][deletions] += 1
+    splice_site_data["deletions"][count_of_deletions] += 1
 
 
 def extract_splice_site_locations_within_aligned_read(read_start: int, read_end: int, exons:list):
@@ -117,6 +117,7 @@ def count_deletions_for_splice_site_locations(
     
     # Extract splice site locations within aligned read
     matching_locations = extract_splice_site_locations_within_aligned_read(read_start, read_end, exons)
+    
     logger.debug(f"Matching locations: {matching_locations}")
     # Count deletions for each splice site location
     for splice_site_location, location_type in matching_locations:
@@ -265,6 +266,8 @@ def correct_splice_site_errors(
         strand (str): transcript strand (extracted from first ReadAssignment-object in read_assignments list)
         chr_record (Fasta): FASTA recored, i.e. a single chromosome from a reference
     """
+
+    
     
     locations_with_errors = []
     for splice_site_location, splice_site_data in splice_site_cases.items():

--- a/tests/test_transcript_splice_site_corrector.py
+++ b/tests/test_transcript_splice_site_corrector.py
@@ -40,7 +40,7 @@ class TestMoreConservativeStrategyConditions(TestCase):
         self.assertTrue(result)
 
     def test_sublist_largest_values_exists_returns_false(self):
-        lst = [0, 0, 10, 10, 10, 6, 0, 0]
+        lst = [0, 0, 10, 10, 10, 0, 6, 0]
         n = 4
         result = sublist_largest_values_exists(lst, n)
         self.assertFalse(result)
@@ -247,5 +247,5 @@ class ExtractSpliceSiteLocationsFromAlignedRead(TestCase):
         read_end = 40
         result = extract_splice_site_locations_within_aligned_read(
             read_start, read_end, exons)
-        expected_output = [20, 30 , 40]
+        expected_output = [(20, False), (30, True) , (40, False)]
         self.assertEqual(result, expected_output)

--- a/tests/test_transcript_splice_site_corrector.py
+++ b/tests/test_transcript_splice_site_corrector.py
@@ -368,12 +368,14 @@ class TestCountDeletionsFromSpliceSiteLocations(TestCase):
         read_start = 20
         read_end = 40
         splice_site_cases = {}
+        WINDOW_SIZE = 8
         count_deletions_for_splice_site_locations(
             read_start,
             read_end,
             cigartuples,
             exons,
-            splice_site_cases)
+            splice_site_cases,
+            WINDOW_SIZE)
         expected_result = {
             20: {
                 'location_is_end': False, 

--- a/tests/test_transcript_splice_site_corrector.py
+++ b/tests/test_transcript_splice_site_corrector.py
@@ -367,21 +367,21 @@ class TestCountDeletionsFromSpliceSiteLocations(TestCase):
                 'location_is_end': False, 
                 'deletions': {2: 1}, 
                 'del_pos_distr': [0, 0, 0, 0, 0, 0, 1, 1], 
-                'most_common_deletion': -1, 
+                'most_common_del': -1, 
                 'del_location_has_canonical_nucleotides': False
             },
             30: {
                 'location_is_end': True, 
                 'deletions': {4: 1}, 
                 'del_pos_distr': [0, 0, 0, 1, 1, 1, 1, 0], 
-                'most_common_deletion': -1, 
+                'most_common_del': -1, 
                 'del_location_has_canonical_nucleotides': False
             },
             40: {
                 'location_is_end': False, 
                 'deletions': {0: 1}, 
                 'del_pos_distr': [0, 0, 0, 0, 0, 0, 0, 0], 
-                'most_common_deletion': -1, 
+                'most_common_del': -1, 
                 'del_location_has_canonical_nucleotides': False
             },
         }
@@ -463,3 +463,92 @@ class TestNucleotideExtraction(TestCase):
             chr_record,
             strand)
         self.assertTrue(splice_site_data["del_location_has_canonical_nucleotides"])
+
+
+class TestDeletionComputationAndBaseExtraction(TestCase):
+
+    def test_for_accepted_del_case_nucleotides_are_vefiried(self):
+        splice_site_location = 10
+        splice_site_data  = {
+            "most_common_del": -1,
+            "location_is_end": False,
+            "del_location_has_canonical_nucleotides": False,
+            "deletions": {4: 1},
+            "del_pos_distr": [0, 0, 0, 0, 0, 0, 0, 0],
+        }
+
+        chr_record = "AAAAAAAAAAAAAAG"
+        ACCEPTED_DEL_CASES = [4]
+        strand = "+"
+        compute_most_common_del_and_verify_nucleotides(
+            splice_site_location,
+            splice_site_data,
+            chr_record,
+            ACCEPTED_DEL_CASES,
+            strand)
+        expected_result = {
+            "most_common_del": 4,
+            "location_is_end": False,
+            "del_location_has_canonical_nucleotides": True,
+            "deletions": {4: 1},
+            "del_pos_distr": [0, 0, 0, 0, 0, 0, 0, 0],
+        }
+        self.assertEqual(splice_site_data, expected_result)
+
+
+    def test_for_not_accepted_del_case_nucleotides_are_not_vefiried(self):
+        splice_site_location = 10
+        splice_site_data  = {
+            "most_common_del": -1,
+            "location_is_end": False,
+            "del_location_has_canonical_nucleotides": False,
+            "deletions": {2: 1},
+            "del_pos_distr": [0, 0, 0, 0, 0, 0, 0, 0],
+        }
+
+        chr_record = "AAAAAAAAAAAAAAG"
+        ACCEPTED_DEL_CASES = [4]
+        strand = "+"
+        compute_most_common_del_and_verify_nucleotides(
+            splice_site_location,
+            splice_site_data,
+            chr_record,
+            ACCEPTED_DEL_CASES,
+            strand)
+        expected_result = {
+            "most_common_del": 2,
+            "location_is_end": False,
+            "del_location_has_canonical_nucleotides": False,
+            "deletions": {2: 1},
+            "del_pos_distr": [0, 0, 0, 0, 0, 0, 0, 0],
+        }
+        self.assertEqual(splice_site_data, expected_result)
+    
+    def test_for_accepted_del_case_non_canonical_nucleotides_return_false(self):
+        splice_site_location = 10
+        splice_site_data  = {
+            "most_common_del": -1,
+            "location_is_end": False,
+            "del_location_has_canonical_nucleotides": False,
+            "deletions": {4: 1},
+            "del_pos_distr": [0, 0, 0, 0, 0, 0, 0, 0],
+        }
+
+        chr_record = "AAAAAAAAAAAAAXX"
+        ACCEPTED_DEL_CASES = [4]
+        strand = "+"
+        compute_most_common_del_and_verify_nucleotides(
+            splice_site_location,
+            splice_site_data,
+            chr_record,
+            ACCEPTED_DEL_CASES,
+            strand)
+        expected_result = {
+            "most_common_del": 4,
+            "location_is_end": False,
+            "del_location_has_canonical_nucleotides": False,
+            "deletions": {4: 1},
+            "del_pos_distr": [0, 0, 0, 0, 0, 0, 0, 0],
+        }
+        self.assertEqual(splice_site_data, expected_result)
+        

--- a/tests/test_transcript_splice_site_corrector.py
+++ b/tests/test_transcript_splice_site_corrector.py
@@ -1,6 +1,9 @@
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
+from src.isoform_assignment import ReadAssignment
+
+from src.graph_based_model_construction import GraphBasedModelConstructor
 from src.transcript_splice_site_corrector import (
     extract_location_from_cigar_string,
     count_deletions_from_cigar_codes_in_given_window,
@@ -561,4 +564,29 @@ class TestDeletionComputationAndBaseExtraction(TestCase):
             "del_pos_distr": [0, 0, 0, 0, 0, 0, 0, 0],
         }
         self.assertEqual(splice_site_data, expected_result)
+
+class TestSpliceSiteCorrector(TestCase):
+    
+    
+    def test_error_is_corrected(self):
+        assigned_read_1 = ReadAssignment(read_id="1", assignment_type="test")
+        assigned_read_1.cigartuples = [(0, 10), (2, 4), (0, 6)]
+        assigned_read_1.corrected_exons = [(0, 20)]
+        assigned_read_1.strand = "+"
+        assigned_reads = [assigned_read_1, assigned_read_1, assigned_read_1, assigned_read_1, assigned_read_1]
+        exons = [(0, 5), (10, 20)]
+
+        constructor = GraphBasedModelConstructor(
+            gene_info=MagicMock(),
+            chr_record= "ABCDEFGHIJKLMAGPQRSTUVWXYZ",
+            params=MagicMock(),
+            transcript_counter=0
+        )
+        result = constructor.correct_transcript_splice_sites(exons, assigned_reads)
+
+        expected_result = [(0, 5), (14, 20)]
+        self.assertTrue(result == expected_result)
+
+
         
+    

--- a/tests/test_transcript_splice_site_corrector.py
+++ b/tests/test_transcript_splice_site_corrector.py
@@ -411,7 +411,7 @@ class TestNucleotideExtraction(TestCase):
             "location_is_end": False,
             "canonical_bases_found": False,
         }
-        chr_record = "AAAAAAAAAAAAAAG"
+        chr_record = "AAAAAAAAAAAAAAAG"
         
         strand = "+"
         extract_nucleotides_from_most_common_del_location(
@@ -435,7 +435,7 @@ class TestNucleotideExtraction(TestCase):
         #                 |           |
         #                 v         start pos
         #  A  A  A  A  A  G  C  A  A  A  A  A  A  A  A  
-        chr_record = "AAAAAGCAAAAAAAA"
+        chr_record = "AAAAAAGCAAAAAAAA"
         
         strand = "+"
         extract_nucleotides_from_most_common_del_location(
@@ -452,7 +452,7 @@ class TestNucleotideExtraction(TestCase):
             "location_is_end": False,
             "canonical_bases_found": False,
         }
-        chr_record = "AAAAAAAAAAAAAAC"
+        chr_record = "AAAAAAAAAAAAAAAC"
         
         strand = "-"
         extract_nucleotides_from_most_common_del_location(
@@ -469,7 +469,7 @@ class TestNucleotideExtraction(TestCase):
             "location_is_end": True,
             "canonical_bases_found": False,
         }
-        chr_record = "AAAAACTAAAAAAAA"
+        chr_record = "AAAAAACTAAAAAAAA"
         
         strand = "-"
         extract_nucleotides_from_most_common_del_location(
@@ -492,7 +492,7 @@ class TestDeletionComputationAndBaseExtraction(TestCase):
             "del_pos_distr": [0, 0, 0, 0, 0, 0, 0, 0],
         }
 
-        chr_record = "AAAAAAAAAAAAAAG"
+        chr_record = "AAAAAAAAAAAAAAAG"
         ACCEPTED_DEL_CASES = [4]
         strand = "+"
         compute_most_common_del_and_verify_nucleotides(
@@ -521,7 +521,7 @@ class TestDeletionComputationAndBaseExtraction(TestCase):
             "del_pos_distr": [0, 0, 0, 0, 0, 0, 0, 0],
         }
 
-        chr_record = "AAAAAAAAAAAAAAG"
+        chr_record = "AAAAAAAAAAAAAAAG"
         ACCEPTED_DEL_CASES = [4]
         strand = "+"
         compute_most_common_del_and_verify_nucleotides(
@@ -549,7 +549,7 @@ class TestDeletionComputationAndBaseExtraction(TestCase):
             "del_pos_distr": [0, 0, 0, 0, 0, 0, 0, 0],
         }
 
-        chr_record = "AAAAAAAAAAAAAXX"
+        chr_record = "AAAAAAAAAAAAAAXX"
         ACCEPTED_DEL_CASES = [4]
         strand = "+"
         compute_most_common_del_and_verify_nucleotides(
@@ -580,7 +580,7 @@ class TestSpliceSiteCorrector(TestCase):
 
         constructor = GraphBasedModelConstructor(
             gene_info=MagicMock(),
-            chr_record= "ABCDEFGHIJKLMAGPQRSTUVWXYZ",
+            chr_record= "ABCDEFGHIJKLMNAGQRSTUVWXYZ",
             params=MagicMock(),
             transcript_counter=0
         )
@@ -600,7 +600,7 @@ class TestSpliceSiteCorrector(TestCase):
 
         constructor = GraphBasedModelConstructor(
             gene_info=MagicMock(),
-            chr_record= "ABCDEFGHIGCLMNOPQRSTUVWXYZ",
+            chr_record= "ABCDEFGHIJGCMNOPQRSTUVWXYZ",
             params=MagicMock(),
             transcript_counter=0
         )
@@ -620,7 +620,7 @@ class TestSpliceSiteCorrector(TestCase):
 
         constructor = GraphBasedModelConstructor(
             gene_info=MagicMock(),
-            chr_record= "ABCDEFGHIJKLMGCPQRSTUVWXYZ",
+            chr_record= "ABCDEFGHIJKLMNGCQRSTUVWXYZ",
             params=MagicMock(),
             transcript_counter=0
         )
@@ -640,7 +640,7 @@ class TestSpliceSiteCorrector(TestCase):
 
         constructor = GraphBasedModelConstructor(
             gene_info=MagicMock(),
-            chr_record= "ABCDEFGHICTLMNOPQRSTUVWXYZ",
+            chr_record= "ABCDEFGHIJCTMNOPQRSTUVWXYZ",
             params=MagicMock(),
             transcript_counter=0
         )
@@ -659,7 +659,7 @@ class TestSpliceSiteCorrector(TestCase):
 
         constructor = GraphBasedModelConstructor(
             gene_info=MagicMock(),
-            chr_record= "ABCDEFGHIJCTMNOPQRSTUVWXYZ",
+            chr_record= "ABCDEFGHIJKCTNOPQRSTUVWXYZ",
             params=MagicMock(),
             transcript_counter=0
         )
@@ -678,7 +678,7 @@ class TestSpliceSiteCorrector(TestCase):
 
         constructor = GraphBasedModelConstructor(
             gene_info=MagicMock(),
-            chr_record= "ABCDEFGCTJKLMNOPQRSTUVWXYZ",
+            chr_record= "ABCDEFGHCTKLMNOPQRSTUVWXYZ",
             params=MagicMock(),
             transcript_counter=0
         )
@@ -718,7 +718,7 @@ class TestSpliceSiteCorrector(TestCase):
 
         constructor = GraphBasedModelConstructor(
             gene_info=MagicMock(),
-            chr_record= "ABCDEFGHIGCLMNOPQRSTUVWXYZ",
+            chr_record= "ABCDEFGHIJGCMNOPQRSTUVWXYZ",
             params=MagicMock(),
             transcript_counter=0
         )

--- a/tests/test_transcript_splice_site_corrector.py
+++ b/tests/test_transcript_splice_site_corrector.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from src.transcript_splice_site_corrector import (
     extract_location_from_cigar_string,
@@ -9,12 +9,18 @@ from src.transcript_splice_site_corrector import (
     compute_most_common_case_of_deletions,
     extract_nucleotides_from_most_common_del_location,
     compute_most_common_del_and_verify_nucleotides,
-    threshold_exceeded,
+    threshold_for_del_cases_exceeded,
     sublist_largest_values_exists,
     correct_splice_site_errors,
     generate_updated_exon_list,
 )
 
+#######################################################################
+##                                                                   ##
+## Run tests with:                                                   ##
+## python -m unittest tests/test_transcript_splice_site_corrector.py ##
+##                                                                   ##
+#######################################################################
 class TestMoreConservativeStrategyConditions(TestCase):
     
     def test_threshold_exceeds_returns_true(self):
@@ -22,7 +28,7 @@ class TestMoreConservativeStrategyConditions(TestCase):
         del_pos_distr = [0, 0, 10, 10, 10, 10, 0, 0]
         deletions = {4: 10}
         most_common_del = 4
-        result = threshold_exceeded(
+        result = threshold_for_del_cases_exceeded(
             del_pos_distr,
             deletions,
             most_common_del,
@@ -34,7 +40,7 @@ class TestMoreConservativeStrategyConditions(TestCase):
         del_pos_distr = [0, 0, 10, 10, 10, 6, 0, 0]
         deletions = {4: 6, 3: 4}
         most_common_del = 4
-        result = threshold_exceeded(
+        result = threshold_for_del_cases_exceeded(
             del_pos_distr,
             deletions,
             most_common_del,
@@ -334,6 +340,7 @@ class TestCorrectSpliceSiteErrors(TestCase):
         }
         MIN_N_ALIGNED_READS = 5
         ACCEPTED_DEL_CASES = [4]
+        THRESHOLD_CASES_AT_LOCATION = 0.7
         MORE_CONSERVATIVE_STRATEGY = False
         strand = "+"
         chr_record = None
@@ -341,6 +348,7 @@ class TestCorrectSpliceSiteErrors(TestCase):
             splice_site_cases,
             MIN_N_ALIGNED_READS,
             ACCEPTED_DEL_CASES,
+            THRESHOLD_CASES_AT_LOCATION,
             MORE_CONSERVATIVE_STRATEGY,
             strand,
             chr_record)
@@ -350,6 +358,7 @@ class TestCorrectSpliceSiteErrors(TestCase):
 class TestCountDeletionsFromSpliceSiteLocations(TestCase):
     def test_count_deletions_from_splice_site_locations_extracts_correct_locations(self):
         exons = [(1, 10), (20, 30), (40, 50)]
+        # Cigar codes for indeces 20-40:
         #  20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 
         # [M ,M, M, M, M, M, D, D, D, D, M, M, M, M, M, M, M, M, M, M, M]
         cigartuples = [(0, 6), (2, 4), (0, 10)]
@@ -415,6 +424,7 @@ class TestNucleotideExtraction(TestCase):
             "del_location_has_canonical_nucleotides": False,
         }
         
+        #  Fasta 1-based index extraction location:
         #  1  2  3  4  5  6  7  8  9  10 11 12 13 14 15
         #              offset of -4   ^
         #                 |           |

--- a/tests/test_transcript_splice_site_corrector.py
+++ b/tests/test_transcript_splice_site_corrector.py
@@ -1,0 +1,251 @@
+from unittest import TestCase
+from unittest import main as unittest_main
+
+
+from src.transcript_splice_site_corrector import threshold_exceeded
+from src.transcript_splice_site_corrector import sublist_largest_values_exists
+from src.transcript_splice_site_corrector import extract_location_from_cigar_string
+from src.transcript_splice_site_corrector import count_deletions_from_cigar_codes_in_given_window
+from src.transcript_splice_site_corrector import extract_splice_site_locations_within_aligned_read
+class TestMoreConservativeStrategyConditions(TestCase):
+    
+    def test_threshold_exceeds_returns_true(self):
+        THRESHOLD = 0.7
+        del_pos_distr = [0, 0, 10, 10, 10, 10, 0, 0]
+        deletions = {4: 10}
+        most_common_del = 4
+        result = threshold_exceeded(
+            del_pos_distr,
+            deletions,
+            most_common_del,
+            THRESHOLD)
+        self.assertTrue(result)
+
+    def test_threshold_not_exceeded_returns_false(self):
+        THRESHOLD = 0.7
+        del_pos_distr = [0, 0, 10, 10, 10, 6, 0, 0]
+        deletions = {4: 6, 3: 4}
+        most_common_del = 4
+        result = threshold_exceeded(
+            del_pos_distr,
+            deletions,
+            most_common_del,
+            THRESHOLD)
+        self.assertFalse(result)
+
+    def test_sublist_largest_values_exists_returns_true(self):
+        lst = [0, 0, 10, 10, 10, 10, 0, 0]
+        n = 4
+        result = sublist_largest_values_exists(lst, n)
+        self.assertTrue(result)
+
+    def test_sublist_largest_values_exists_returns_false(self):
+        lst = [0, 0, 10, 10, 10, 6, 0, 0]
+        n = 4
+        result = sublist_largest_values_exists(lst, n)
+        self.assertFalse(result)
+        
+
+class TestExtractingLocationFromCigarString(TestCase):
+
+    def test_cigar_string_with_soft_clip_and_one_match_is_parsed_correctly(self):
+        cigar = [(4, 50), (0, 10)]
+        reference_start = 100
+        reference_end = 160
+        location = 105
+        expected_output = 55
+        result = extract_location_from_cigar_string(
+            cigar, reference_start, reference_end, location)
+        self.assertEqual(result, expected_output)
+        
+
+    def test_cigar_string_with_soft_clip_insertion_and_one_match_is_parsed_correctly(self):
+        cigar = [(4, 50), (1, 10), (0, 10)]
+        reference_start = 100
+        reference_end = 160
+        location = 105
+        expected_output = 65
+        result = extract_location_from_cigar_string(
+            cigar, reference_start, reference_end, location)
+        self.assertEqual(result, expected_output)
+        
+
+    def test_cigar_str_with_s_d_i_m_gives_correct_output(self):
+        cigar = [(4, 50), (2, 10), (1, 10), (0, 10)]
+        reference_start = 100
+        reference_end = 160
+        location = 115
+        expected_output = 75
+        result = extract_location_from_cigar_string(
+            cigar, reference_start, reference_end, location)
+        self.assertEqual(result, expected_output)
+
+    def test_cigar_str_with_s_d_n_m_gives_correct_output(self):
+        cigar = [(4, 50), (2, 10), (3, 100), (0, 10)]
+        reference_start = 100
+        reference_end = 160
+        location = 215
+        expected_output = 165
+        result = extract_location_from_cigar_string(
+            cigar, reference_start, reference_end, location)
+        self.assertEqual(result, expected_output)
+
+    def test_cigar_str_with_s_m_i_n_m_gives_correct_output(self):
+        cigar = [(4, 50), (0, 10), (1, 10), (3, 100), (0, 10)]
+        reference_start = 100
+        reference_end = 160
+        location = 215
+        expected_output = 175
+        result = extract_location_from_cigar_string(
+            cigar, reference_start, reference_end, location)
+        self.assertEqual(result, expected_output)
+
+    def test_location_outside_of_cigar_str_returns_minus_one(self):
+        cigar = [(4, 50), (0, 10)]
+        reference_start = 100
+        reference_end = 160
+        location = 199
+        expected_output = -1
+        result = extract_location_from_cigar_string(
+            cigar, reference_start, reference_end, location)
+        self.assertEqual(result, expected_output)
+
+    def test_more_complicated_test_returns_correct_position(self):
+        cigar_tuples = [(4, 156), (0, 12), (2, 3), (0, 2), (2, 2), (0, 10), (2, 2), (0, 4), (2, 3), (0, 7), (1, 1), (0, 16), (1, 4), (0, 23), (1, 1), (0, 7),
+                        (1, 1), (0, 9), (2, 1), (0, 13), (2, 1), (0, 15), (2, 2), (0, 3), (1, 2), (0, 19), (2, 2), (0, 20), (2, 1), (0, 32), (3, 294), (0, 36), (4, 25)]
+        reference_start = 72822568
+        reference_end = 73822568
+        position = 72823071
+        expected_output = 668
+        result = extract_location_from_cigar_string(
+            cigar_tuples, reference_start, reference_end, position)
+        self.assertEqual(result, expected_output)
+
+    def test_case_that_does_not_consume_any_reference_returns_the_correct_location(self):
+        cigar = [(4, 50), (0, 10)]
+        reference_start = 100
+        reference_end = 160
+        location = 100
+        expected_output = 50
+        result = extract_location_from_cigar_string(
+            cigar, reference_start, reference_end, location)
+        self.assertEqual(result, expected_output)
+
+    def test_case_that_has_no_reference_consuming_codes_returns_minus_one_as_error(self):
+        cigar = [(4, 50), (1, 10)]
+        reference_start = 100
+        reference_end = 160
+        location = 100
+        expected_output = -1
+        result = extract_location_from_cigar_string(
+            cigar, reference_start, reference_end, location)
+        self.assertEqual(result, expected_output)
+
+    def test_case_that_has_no_reference_consuming_codes_at_the_end_returns_minus_one_as_error(self):
+        cigar = [(4, 50), (0, 10), (1, 10)]
+        reference_start = 100
+        reference_end = 160
+        location = 110
+        expected_output = -1
+        result = extract_location_from_cigar_string(
+            cigar, reference_start, reference_end, location)
+        self.assertEqual(result, expected_output)
+
+    def test_case_that_has_it_s_location_at_final_match_returns_correct_value(self):
+        cigar = [(4, 50), (0, 10), (1, 10)]
+        reference_start = 100
+        reference_end = 110
+        location = 110
+        expected_output = 60
+        result = extract_location_from_cigar_string(
+            cigar, reference_start, reference_end, location)
+        self.assertEqual(result, expected_output)
+
+
+class TestIndelCountingFromCigarCodes(TestCase):
+
+    def setUp(self):
+        self.window_size = 8
+
+    def test_indel_counter_returns_false_and_an_empty_debug_list_for_given_empty_list(self):
+        cigar_tuples = []
+        aligned_location = 100
+        location_is_end = False
+        splice_site_data = {
+            'deletions': {},
+            "del_pos_distr": [0] * self.window_size,
+        }
+        expected_result = {
+            'deletions': {0: 1},
+            "del_pos_distr": [0, 0, 0, 0, 0, 0, 0, 0]
+        }
+        count_deletions_from_cigar_codes_in_given_window(
+            cigar_tuples,
+            aligned_location,
+            location_is_end,
+            splice_site_data,
+            self.window_size)
+        
+        self.assertEqual(splice_site_data['deletions'], expected_result['deletions'])
+        self.assertEqual(splice_site_data['del_pos_distr'], expected_result['del_pos_distr'])
+        
+
+        
+    def test_indels_are_counted_correctly(self):
+        cigar_tuples = [(0, 20), (2, 3), (1, 2), (0, 10)]
+        aligned_location = 27
+        location_is_end = True
+        splice_site_data = {
+            'deletions': {},
+            "del_pos_distr": [0] * self.window_size,
+        }
+
+
+        expected_result = {
+            'deletions': {3: 1},
+            "del_pos_distr": [1, 1, 1, 0, 0, 0, 0, 0]
+        }
+
+        count_deletions_from_cigar_codes_in_given_window(
+            cigar_tuples,
+            aligned_location,
+            location_is_end,
+            splice_site_data,
+            self.window_size)
+
+        self.assertEqual(splice_site_data['deletions'], expected_result['deletions'])
+        self.assertEqual(splice_site_data['del_pos_distr'], expected_result['del_pos_distr'])
+
+    def test_full_window_of_dels_returns_true_for_errors(self):
+        cigar_tuples = [(0, 20), (2, 8), (1, 2), (0, 10)]
+        aligned_location = 20
+        location_is_end = False
+        splice_site_data = {
+            'deletions': {},
+            "del_pos_distr": [0] * self.window_size,
+        }
+        expected_result = {
+            'deletions': {8: 1},
+            "del_pos_distr": [1, 1, 1, 1, 1, 1, 1, 1]
+        }
+
+        count_deletions_from_cigar_codes_in_given_window(
+            cigar_tuples,
+            aligned_location,
+            location_is_end,
+            splice_site_data,
+            self.window_size)
+
+        self.assertEqual(splice_site_data['deletions'], expected_result['deletions'])
+        self.assertEqual(splice_site_data['del_pos_distr'], expected_result['del_pos_distr'])
+
+class ExtractSpliceSiteLocationsFromAlignedRead(TestCase):
+
+    def test_correct_splice_sites_are_extracted(self):
+        exons = [(1, 10), (20, 30), (40, 50)]
+        read_start = 20
+        read_end = 40
+        result = extract_splice_site_locations_within_aligned_read(
+            read_start, read_end, exons)
+        expected_output = [20, 30 , 40]
+        self.assertEqual(result, expected_output)

--- a/tests/test_transcript_splice_site_corrector.py
+++ b/tests/test_transcript_splice_site_corrector.py
@@ -329,13 +329,13 @@ class TestCorrectSpliceSiteErrors(TestCase):
     def test_errors_are_correctly_returned(self, mock_compute_most_common_case_of_deletions):
         splice_site_cases = {
             20: {
-                "del_location_has_canonical_nucleotides": False,
+                "canonical_bases_found": False,
                 "deletions": {4: 10},
                 "location_is_end": False,
                 "most_common_del": 4,
             },
             30: {
-                "del_location_has_canonical_nucleotides": True,
+                "canonical_bases_found": True,
                 "deletions": {4: 10},
                 "location_is_end": False,
                 "most_common_del": 4,
@@ -382,21 +382,21 @@ class TestCountDeletionsFromSpliceSiteLocations(TestCase):
                 'deletions': {2: 1}, 
                 'del_pos_distr': [0, 0, 0, 0, 0, 0, 1, 1], 
                 'most_common_del': -1, 
-                'del_location_has_canonical_nucleotides': False
+                'canonical_bases_found': False
             },
             30: {
                 'location_is_end': True, 
                 'deletions': {4: 1}, 
                 'del_pos_distr': [0, 0, 0, 1, 1, 1, 1, 0], 
                 'most_common_del': -1, 
-                'del_location_has_canonical_nucleotides': False
+                'canonical_bases_found': False
             },
             40: {
                 'location_is_end': False, 
                 'deletions': {0: 1}, 
                 'del_pos_distr': [0, 0, 0, 0, 0, 0, 0, 0], 
                 'most_common_del': -1, 
-                'del_location_has_canonical_nucleotides': False
+                'canonical_bases_found': False
             },
         }
         self.assertEqual(splice_site_cases, expected_result)
@@ -409,7 +409,7 @@ class TestNucleotideExtraction(TestCase):
         splice_site_data = {
             "most_common_del": 4,
             "location_is_end": False,
-            "del_location_has_canonical_nucleotides": False,
+            "canonical_bases_found": False,
         }
         chr_record = "AAAAAAAAAAAAAAG"
         
@@ -419,14 +419,14 @@ class TestNucleotideExtraction(TestCase):
             splice_site_data,
             chr_record,
             strand)
-        self.assertTrue(splice_site_data["del_location_has_canonical_nucleotides"])
+        self.assertTrue(splice_site_data["canonical_bases_found"])
 
     def test_canonical_nucleotides_for_loc_end_pos_strand_are_extracted_correctly(self):
         location = 10
         splice_site_data = {
             "most_common_del": -4,
             "location_is_end": True,
-            "del_location_has_canonical_nucleotides": False,
+            "canonical_bases_found": False,
         }
         
         #  Fasta 1-based index extraction location:
@@ -443,14 +443,14 @@ class TestNucleotideExtraction(TestCase):
             splice_site_data,
             chr_record,
             strand)
-        self.assertTrue(splice_site_data["del_location_has_canonical_nucleotides"])
+        self.assertTrue(splice_site_data["canonical_bases_found"])
 
     def test_canonical_nucleotides_for_loc_start_neg_strand_are_extracted_correctly(self):
         location = 10
         splice_site_data = {
             "most_common_del": 4,
             "location_is_end": False,
-            "del_location_has_canonical_nucleotides": False,
+            "canonical_bases_found": False,
         }
         chr_record = "AAAAAAAAAAAAAAC"
         
@@ -460,14 +460,14 @@ class TestNucleotideExtraction(TestCase):
             splice_site_data,
             chr_record,
             strand)
-        self.assertTrue(splice_site_data["del_location_has_canonical_nucleotides"])
+        self.assertTrue(splice_site_data["canonical_bases_found"])
 
     def test_canonical_nucleotides_for_loc_end_neg_strand_are_extracted_correctly(self):
         location = 10
         splice_site_data = {
             "most_common_del": -4,
             "location_is_end": True,
-            "del_location_has_canonical_nucleotides": False,
+            "canonical_bases_found": False,
         }
         chr_record = "AAAAACTAAAAAAAA"
         
@@ -477,7 +477,7 @@ class TestNucleotideExtraction(TestCase):
             splice_site_data,
             chr_record,
             strand)
-        self.assertTrue(splice_site_data["del_location_has_canonical_nucleotides"])
+        self.assertTrue(splice_site_data["canonical_bases_found"])
 
 
 class TestDeletionComputationAndBaseExtraction(TestCase):
@@ -487,7 +487,7 @@ class TestDeletionComputationAndBaseExtraction(TestCase):
         splice_site_data  = {
             "most_common_del": -1,
             "location_is_end": False,
-            "del_location_has_canonical_nucleotides": False,
+            "canonical_bases_found": False,
             "deletions": {4: 1},
             "del_pos_distr": [0, 0, 0, 0, 0, 0, 0, 0],
         }
@@ -504,7 +504,7 @@ class TestDeletionComputationAndBaseExtraction(TestCase):
         expected_result = {
             "most_common_del": 4,
             "location_is_end": False,
-            "del_location_has_canonical_nucleotides": True,
+            "canonical_bases_found": True,
             "deletions": {4: 1},
             "del_pos_distr": [0, 0, 0, 0, 0, 0, 0, 0],
         }
@@ -516,7 +516,7 @@ class TestDeletionComputationAndBaseExtraction(TestCase):
         splice_site_data  = {
             "most_common_del": -1,
             "location_is_end": False,
-            "del_location_has_canonical_nucleotides": False,
+            "canonical_bases_found": False,
             "deletions": {2: 1},
             "del_pos_distr": [0, 0, 0, 0, 0, 0, 0, 0],
         }
@@ -533,7 +533,7 @@ class TestDeletionComputationAndBaseExtraction(TestCase):
         expected_result = {
             "most_common_del": 2,
             "location_is_end": False,
-            "del_location_has_canonical_nucleotides": False,
+            "canonical_bases_found": False,
             "deletions": {2: 1},
             "del_pos_distr": [0, 0, 0, 0, 0, 0, 0, 0],
         }
@@ -544,7 +544,7 @@ class TestDeletionComputationAndBaseExtraction(TestCase):
         splice_site_data  = {
             "most_common_del": -1,
             "location_is_end": False,
-            "del_location_has_canonical_nucleotides": False,
+            "canonical_bases_found": False,
             "deletions": {4: 1},
             "del_pos_distr": [0, 0, 0, 0, 0, 0, 0, 0],
         }
@@ -561,7 +561,7 @@ class TestDeletionComputationAndBaseExtraction(TestCase):
         expected_result = {
             "most_common_del": 4,
             "location_is_end": False,
-            "del_location_has_canonical_nucleotides": False,
+            "canonical_bases_found": False,
             "deletions": {4: 1},
             "del_pos_distr": [0, 0, 0, 0, 0, 0, 0, 0],
         }

--- a/tests/test_transcript_splice_site_corrector.py
+++ b/tests/test_transcript_splice_site_corrector.py
@@ -600,7 +600,7 @@ class TestSpliceSiteCorrector(TestCase):
 
         constructor = GraphBasedModelConstructor(
             gene_info=MagicMock(),
-            chr_record= "ABCDEFGIJGCMNOPQRSTUVWXYZ",
+            chr_record= "ABCDEFGHIGCLMNOPQRSTUVWXYZ",
             params=MagicMock(),
             transcript_counter=0
         )
@@ -640,13 +640,52 @@ class TestSpliceSiteCorrector(TestCase):
 
         constructor = GraphBasedModelConstructor(
             gene_info=MagicMock(),
-            chr_record= "ABCDEFGIJCTMNOPQRSTUVWXYZ",
+            chr_record= "ABCDEFGHICTLMNOPQRSTUVWXYZ",
             params=MagicMock(),
             transcript_counter=0
         )
         result = constructor.correct_transcript_splice_sites(exons, assigned_reads)
 
         expected_result = [(0, 10), (20, 30)]
+        self.assertTrue(result == expected_result)
+
+    def test_error_in_end_on_neg_strand_and_min_accepted_del_cases_is_corrected(self):
+        assigned_read_1 = ReadAssignment(read_id="1", assignment_type="test")
+        assigned_read_1.cigartuples = [(0, 10), (2, 3), (0, 17)]
+        assigned_read_1.corrected_exons = [(0, 20)]
+        assigned_read_1.strand = "-"
+        assigned_reads = [assigned_read_1, assigned_read_1, assigned_read_1, assigned_read_1, assigned_read_1]
+        exons = [(0, 14), (20, 30)]
+
+        constructor = GraphBasedModelConstructor(
+            gene_info=MagicMock(),
+            chr_record= "ABCDEFGHIJCTMNOPQRSTUVWXYZ",
+            params=MagicMock(),
+            transcript_counter=0
+        )
+        result = constructor.correct_transcript_splice_sites(exons, assigned_reads)
+
+        expected_result = [(0, 11), (20, 30)]
+        self.assertTrue(result == expected_result)
+
+    def test_error_in_end_on_neg_strand_and_max_accepted_del_cases_is_corrected(self):
+        assigned_read_1 = ReadAssignment(read_id="1", assignment_type="test")
+        assigned_read_1.cigartuples = [(0, 8), (2, 6), (0, 16)]
+        assigned_read_1.corrected_exons = [(0, 20)]
+        assigned_read_1.strand = "-"
+        assigned_reads = [assigned_read_1, assigned_read_1, assigned_read_1, assigned_read_1, assigned_read_1]
+        exons = [(0, 14), (20, 30)]
+
+        constructor = GraphBasedModelConstructor(
+            gene_info=MagicMock(),
+            chr_record= "ABCDEFGCTJKLMNOPQRSTUVWXYZ",
+            params=MagicMock(),
+            transcript_counter=0
+        )
+        result = constructor.correct_transcript_splice_sites(exons, assigned_reads)
+        
+
+        expected_result = [(0, 8), (20, 30)]
         self.assertTrue(result == expected_result)
 
 
@@ -660,7 +699,7 @@ class TestSpliceSiteCorrector(TestCase):
 
         constructor = GraphBasedModelConstructor(
             gene_info=MagicMock(),
-            chr_record= "ABCDEFGIJKLMNOPQRSTUVWXYZ",
+            chr_record= "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
             params=MagicMock(),
             transcript_counter=0
         )
@@ -669,4 +708,21 @@ class TestSpliceSiteCorrector(TestCase):
         expected_result = None
         self.assertTrue(result == expected_result)
 
-    
+    def test_case_with_not_enough_dels_but_canonicals_in_end_on_pos_strand_returns_none(self):
+        assigned_read_1 = ReadAssignment(read_id="1", assignment_type="test")
+        assigned_read_1.cigartuples = [(0, 10), (2, 2), (0, 18)]
+        assigned_read_1.corrected_exons = [(0, 20)]
+        assigned_read_1.strand = "-"
+        assigned_reads = [assigned_read_1, assigned_read_1, assigned_read_1, assigned_read_1, assigned_read_1]
+        exons = [(0, 14), (20, 30)]
+
+        constructor = GraphBasedModelConstructor(
+            gene_info=MagicMock(),
+            chr_record= "ABCDEFGHIGCLMNOPQRSTUVWXYZ",
+            params=MagicMock(),
+            transcript_counter=0
+        )
+        result = constructor.correct_transcript_splice_sites(exons, assigned_reads)
+
+        expected_result = None
+        self.assertTrue(result == expected_result)

--- a/tests/test_transcript_splice_site_corrector.py
+++ b/tests/test_transcript_splice_site_corrector.py
@@ -568,7 +568,7 @@ class TestDeletionComputationAndBaseExtraction(TestCase):
 class TestSpliceSiteCorrector(TestCase):
     
     
-    def test_error_is_corrected(self):
+    def test_error_in_start_on_pos_strand_is_corrected(self):
         assigned_read_1 = ReadAssignment(read_id="1", assignment_type="test")
         assigned_read_1.cigartuples = [(0, 10), (2, 4), (0, 6)]
         assigned_read_1.corrected_exons = [(0, 20)]
@@ -588,5 +588,83 @@ class TestSpliceSiteCorrector(TestCase):
         self.assertTrue(result == expected_result)
 
 
-        
+    def test_error_in_end_on_pos_strand_is_corrected(self):
+        assigned_read_1 = ReadAssignment(read_id="1", assignment_type="test")
+        assigned_read_1.cigartuples = [(0, 10), (2, 4), (0, 16)]
+        assigned_read_1.corrected_exons = [(0, 20)]
+        assigned_read_1.strand = "+"
+        assigned_reads = [assigned_read_1, assigned_read_1, assigned_read_1, assigned_read_1, assigned_read_1]
+        exons = [(0, 14), (20, 30)]
+
+        constructor = GraphBasedModelConstructor(
+            gene_info=MagicMock(),
+            chr_record= "ABCDEFGIJGCMNOPQRSTUVWXYZ",
+            params=MagicMock(),
+            transcript_counter=0
+        )
+        result = constructor.correct_transcript_splice_sites(exons, assigned_reads)
+
+        expected_result = [(0, 10), (20, 30)]
+        self.assertTrue(result == expected_result)
+
+
+    def test_error_in_start_on_neg_strand_is_corrected(self):
+        assigned_read_1 = ReadAssignment(read_id="1", assignment_type="test")
+        assigned_read_1.cigartuples = [(0, 10), (2, 4), (0, 6)]
+        assigned_read_1.corrected_exons = [(0, 20)]
+        assigned_read_1.strand = "-"
+        assigned_reads = [assigned_read_1, assigned_read_1, assigned_read_1, assigned_read_1, assigned_read_1]
+        exons = [(0, 5), (10, 20)]
+
+        constructor = GraphBasedModelConstructor(
+            gene_info=MagicMock(),
+            chr_record= "ABCDEFGHIJKLMGCPQRSTUVWXYZ",
+            params=MagicMock(),
+            transcript_counter=0
+        )
+        result = constructor.correct_transcript_splice_sites(exons, assigned_reads)
+
+        expected_result = [(0, 5), (14, 20)]
+        self.assertTrue(result == expected_result)
+
+
+    def test_error_in_end_on_neg_strand_is_corrected(self):
+        assigned_read_1 = ReadAssignment(read_id="1", assignment_type="test")
+        assigned_read_1.cigartuples = [(0, 10), (2, 4), (0, 16)]
+        assigned_read_1.corrected_exons = [(0, 20)]
+        assigned_read_1.strand = "-"
+        assigned_reads = [assigned_read_1, assigned_read_1, assigned_read_1, assigned_read_1, assigned_read_1]
+        exons = [(0, 14), (20, 30)]
+
+        constructor = GraphBasedModelConstructor(
+            gene_info=MagicMock(),
+            chr_record= "ABCDEFGIJCTMNOPQRSTUVWXYZ",
+            params=MagicMock(),
+            transcript_counter=0
+        )
+        result = constructor.correct_transcript_splice_sites(exons, assigned_reads)
+
+        expected_result = [(0, 10), (20, 30)]
+        self.assertTrue(result == expected_result)
+
+
+    def test_case_with_dels_but_no_canonicals_in_end_on_neg_strand_returns_none(self):
+        assigned_read_1 = ReadAssignment(read_id="1", assignment_type="test")
+        assigned_read_1.cigartuples = [(0, 10), (2, 4), (0, 16)]
+        assigned_read_1.corrected_exons = [(0, 20)]
+        assigned_read_1.strand = "-"
+        assigned_reads = [assigned_read_1, assigned_read_1, assigned_read_1, assigned_read_1, assigned_read_1]
+        exons = [(0, 14), (20, 30)]
+
+        constructor = GraphBasedModelConstructor(
+            gene_info=MagicMock(),
+            chr_record= "ABCDEFGIJKLMNOPQRSTUVWXYZ",
+            params=MagicMock(),
+            transcript_counter=0
+        )
+        result = constructor.correct_transcript_splice_sites(exons, assigned_reads)
+
+        expected_result = None
+        self.assertTrue(result == expected_result)
+
     


### PR DESCRIPTION
## Introduction

This pull request adds a new feature for predicting and correcting errors in long reads to IsoQuant. 

## Constants

The constants are collected in the start of the function correct_transcript_splice_sites from which the code execution starts. This way they can be conveniently moved outside of the function or re-configured in the future, if needed. One possible use case would be to give the user the option to select a strategy to use, or alter the constants with arguments.  

```python
def correct_transcript_splice_sites(arguments):
  # ...
  
  ACCEPTED_DEL_CASES = [3, 4, 5, 6]
  SUPPORTED_STRANDS = ['+', '-']
  THRESHOLD_CASES_AT_LOCATION = 0.7
  MIN_N_OF_ALIGNED_READS = 5
  WINDOW_SIZE = 8
  MORE_CONSERVATIVE_STRATEGY = False
  
  # ...
```

> [!NOTE]
> Constant "Threshold cases at location" is only used when "More conservative strategy" is True. See section "error prediction strategies" for additional information. 

## Extracting cases and computing deletions

The assigned_reads list contains ReadAssignment objects. From each read start and end locations and cigartuples are extracted and for each splice site between the start and end location deletions are counted. First the locations within start and end of read are extracted from the exons-list. It is important to note that a read my start and end in the middle of an exon. 

```python
for read_assignment in assigned_reads:
    read_start = read_assignment.corrected_exons[0][0]
    read_end = read_assignment.corrected_exons[-1][1]
    cigartuples = read_assignment.cigartuples
    if not cigartuples:
        continue
    count_deletions_for_splice_site_locations(arguments)
```

For each matching location the location is first added to the splice_cite_cases dictionary, if missing. After this the deletions are computed from the cigartuples.

> [!NOTE]
> The key-value 'del_pos_distr' is only needed for the more conservative strategy. 

```python
def count_deletions_for_splice_site_locations(arguments):
    
    matching_locations = extract_splice_site_locations_within_aligned_read(read_start, read_end, exons)
    
    for location in matching_locations:
        if location not in splice_site_cases:
            splice_site_cases[location] = {
                'location_is_end': bool,  
                'deletions': {},
                'del_pos_distr': [0 for _ in range(WINDOW_SIZE)],
                'most_common_del': -1,
                'canonical_bases_found': False
            }
        
        aligned_location = extract_location_from_cigar_string(arguments)
        
        count_deletions_from_cigar_codes_in_given_window(arguments)
```
The data structure of information to be extracted is the following: 

```python
{
    'location': 
        {
            'location_is_end': bool,  
            'deletions': dict,
            'del_pos_distr': list,
            'most_common_del': int,
            'canonical_bases_found': bool
        }
}
```

- **location\_is\_end:** A boolean indicating whether the location is the end of an exon
- **deletions:** A dictionary with number of deletions as key and count of reads as value
- **del\_pos\_distr:** A list of integers with length of the predefined window. Each index contains the count of deletions in the respective position in the window. 
- **most\_common\_del:** Integer presenting the most common case of deletion. If no distinct case is found, the value is $-1$. The value also indicates direction. If the location is the start of an exon, the value is positive. Otherwise the value is negative. 
- **canonical\_bases\_found:**}** A boolean stating whether there exists candidate bases for a canonical pair at the distance of the most\_common\_del from the current location. 

The computation of deletions from cigartuples happens in two steps. First the aligned location is extracted from the cigartuple:

```python
def extract_location_from_cigar_string(arguments):
    relative_position = splice_site_location - read_start
    alignment_position = 0
    ref_position = 0

    for cigar_code in cigartuples:

        if cigar_code[0] in [0, 2, 3, 7, 8]:
            ref_position += cigar_code[1]
        if ref_position <= relative_position and not \
                read_start + ref_position == read_end:
            alignment_position += cigar_code[1]
        else:
            return alignment_position + (cigar_code[1] - (ref_position - relative_position))

    return -1
```


After this, the cigartuple is iterated again and starting from the aligned location a length of the predefined window_size cigarcodes are extracted. 

> [!NOTE]
> This part of the code could be optimized by performing these two operations at once. 


```python
def count_deletions_from_cigar_codes_in_given_window(arguments):
    count_of_deletions = 0
    
    cigar_code_list = []
    location = 0

    if location_is_end:
        aligned_location = aligned_location - window_size + 1

    for cigar_code in cigartuples:
        if window_size == len(cigar_code_list):
            break
        if location + cigar_code[1] > aligned_location:
            overlap = location + \
                cigar_code[1] - (aligned_location + len(cigar_code_list))
            cigar_code_list.extend(
                [cigar_code[0] for _ in range(min(window_size -
                                                len(cigar_code_list), overlap))])
        location += cigar_code[1]

    for i in range(window_size):
        if i >= len(cigar_code_list):
            break
        if cigar_code_list[i] == 2:
            count_of_deletions += 1
            splice_site_data["del_pos_distr"][i] += 1
    
    if count_of_deletions not in splice_site_data["deletions"]:
        splice_site_data["deletions"][count_of_deletions] = 0
    
    splice_site_data["deletions"][count_of_deletions] += 1
```


## Correcting errors

The main function iterates through all extracted cases. If the reads aligned to the given location exceed MIN_N_OF_ALIGNED_READS, the location is verified for errors. If MORE_CONSERVATIVE_STRATEGY is selected, two additional verifications are made.  


```python
def correct_splice_site_errors(arguments):
    locations_with_errors = []
    for case in splice_cite_locations:
        
        reads = sum of reads at current location
        if reads < MIN_N_OF_ALIGNED_READS:
            continue
        
        compute_most_common_del_and_verify_nucleotides(arguments)
        
        if MORE_CONSERVATIVE_STRATEGY:
            if not sublist_largest_values_exists(arguments):
                continue
            if not threshold_for_del_cases_exceeded(argument):
                continue

        if canonical pair is found:
            locations_with_errors.append(location of case)
    
    return locations_with_errors
```

The most common deletion is stored to the dictionary as it is used in error correction if an error is found. It is stored containing the distance and direction. In exon start location the value is positive and in exon end location the value is negative. For this reason an absolute value is checked against ACCEPTED_DEL_CASES.  

```python
def compute_most_common_del_and_verify_nucleotides(
        arguments):
    
    # Compute most common case of deletions
    splice_site_data["most_common_del"] = compute_most_common_case_of_deletions(
        arguments)
    
    # Extract nucleotides from most common deletion location if it is an accepted case
    if abs(splice_site_data["most_common_del"]) in ACCEPTED_DEL_CASES:
        extract_nucleotides_from_most_common_del_location(
            arguments)
```

For locations with a suitable most common deletion case a candidate bases for a canonical pair are verified. Strand and the location of the case (start or end of exon) is taken into consideration. \\

> [!WARNING]
> At the time it remains an open question whether the index correction is correctly set for IsoQuant. This needs to be verified. 


```python
def extract_nucleotides_from_most_common_del_location(
        arguments):
    idx_correction = 0
    extraction_start = location + most_common_del + idx_correction
    extraction_end = location + most_common_del + 2 + idx_correction
    try:
        extracted_canonicals =  chr_record[extraction_start:extraction_end]
    except KeyError:
        extracted_canonicals = 'XX'
    
    canonical_pairs = {
        '+': {
            'start': ['AG', 'AC'],
            'end': ['GT', 'GC', 'AT']
        },
        '-': {
            'start': ['AC', 'GC', 'AC'],
            'end': ['CT', 'GT']
        }
    }
    
    if location is end:
        possible_canonicals = canonical_pairs[strand]['end']
    else:
        possible_canonicals = canonical_pairs[strand]['start']
    if extracted_canonicals in possible_canonicals:
        splice_site_data["canonical_bases_found"] = True
```

Finally a list of corrected exons is created: 

```python
def generate_updated_exon_list(arguments):
    updated_exons = []
    for exon in exons:
            updated_exon = exon
            if exon[0] in locations_with_errors:
                corrected_location = exon[0] + splice_site_cases[exon[0]]["most_common_del"]
                updated_exon = (corrected_location, exon[1])
            if exon[1] in locations_with_errors:
                corrected_location = exon[1] + splice_site_cases[exon[1]]["most_common_del"]
                updated_exon = (exon[0], corrected_location)
            updated_exons.append(updated_exon)
    return updated_exons
```

In more conservative strategy two additional validations are made. There has to be $n$ adjacent nucleotides that have larger or equal values to nucleotides in other positions (see explanation in next section):

```python
def sublist_largest_values_exists(lst, n):
    largest_values = set(sorted(lst, reverse=True)[:n])
    count = 0

    for num in lst:
        if num in largest_values:
            count += 1
            if count >= n:
                return True
        else:
            count = 0

    return False
```

Additionally there has to be $n$ (not necessarily adjacent nucleotides) for which a preset threshold is exceeded. Note that because of the first additional constraint, we can be certain that in the event of return value being True, clearly all nucleotides in the sublist of largest values also exceed this constraint. 

```python
def threshold_for_del_cases_exceeded(arguments):
    total_cases = sum of deletions
    nucleotides_exceeding_treshold = 0
    for value in del_pos_distr:
        if value  > total_cases * THRESHOLD_CASES_AT_LOCATION:
            nucleotides_exceeding_treshold += 1
    return bool(nucleotides_exceeding_treshold >= abs(most_common_del))
```

## Error prediction strategies

Two strategies for error prediction are available: 

**Conservative:**
\begin{enumerate}
1. There has to be a distinct most common case of deletions and it is one of the accepted deletion cases (constant ACCEPTED_DEL_CASES).
2. There has to be a canonical pair at the distance of the most common case of deletions from the splice site (constant WINDOW_SIZE)
3. The number of aligned reads at the given location must exceed a preset threshold (constant MIN_N_OF_ALIGNED_READS)


**\textbfVery conservative:**
1. There has to be a distinct most common case of deletions and it is one of the accepted deletion cases  (constant ACCEPTED_DEL_CASES).
2. There has to be a canonical pair at the distance of the most common case of deletions from the splice site (constant WINDOW_SIZE)
3. The number of aligned reads at the given location must exceed a preset threshold (constant MIN_N_OF_ALIGNED_READS)
4. There has to be atleast $n$ indeces ($n$ is the distinct most common case of deletions), in which a threshold for deletions has to be exceeded (constant THRESHOLD_CASES_AT_LOCATION)
5. There has to be $n$ adjacent nucleotides that have larger or equal values to nucleotides in other positions (see explanation below)

Elaboration for condition 5: 

Let $S$ be the list of elements in window and $A = \{k_1, \ldots, k_n \}$ be $n$ adjacent indices that is a sublist of $S$. Let $B={h_1,\ldots,h_m}$ be the sublist of the remaining (possibly non-adjacent) indices in $S$, so that $\forall h_i\in B\\;h_i\notin A$, $\forall k_j\in A\\;k_j\notin B$ and $|A| + |B| = |S|$.  

Now for condition 3 to apply it holds that  

$$\forall S[k_j]\\;\not\exists S[h_i]\\;\text{s.t.}\\;S[k_j] < S[h_i].$$

Note: as this is a list of elements, it may have multiple elements with equal value. 