### PR TITLE
Fix default value of --report_canonical to auto

### DIFF
--- a/isoquant.py
+++ b/isoquant.py
@@ -152,7 +152,7 @@ def parse_args(cmd_args=None, namespace=None):
                                    choices=[e.name for e in StrandnessReportingLevel],
                                    help="reporting level for novel transcripts based on canonical splice sites;"
                                         " default: " + StrandnessReportingLevel.auto.name,
-                                   default=StrandnessReportingLevel.only_stranded.name)
+                                   default=StrandnessReportingLevel.auto.name)
     add_additional_option_to_group(algo_args_group, "--polya_requirement", type=str,
                                    choices=[e.name for e in PolyAUsageStrategies],
                                    help="require polyA tails to be present when reporting transcripts; "


### PR DESCRIPTION
This change updates the default value of `--report_canonical` from `only_stranded` to `auto` to match the help text and ensure preset strategies work as intended. When set to `auto`, the code applies the `report_canonical` value from the selected preset strategy; otherwise, the preset value is ignored, leading to inconsistent behavior.