### PR TITLE
fix run_pipeline isoquant_lib import in CI

### DIFF
--- a/isoquant_tests/github/run_pipeline.py
+++ b/isoquant_tests/github/run_pipeline.py
@@ -20,6 +20,10 @@ import logging
 
 import yaml
 
+# Run by absolute path from CI, so the repo root is not on sys.path by default;
+# prepend it so isoquant_lib resolves to this checkout, not an installed copy.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..")))
+
 from isoquant_lib.utils.error_codes import IsoQuantExitCode
 
 


### PR DESCRIPTION
## Problem

All CI pipeline tests fail immediately with:

```
File ".../isoquant_tests/github/run_pipeline.py", line 23, in <module>
    from isoquant_lib.utils.error_codes import IsoQuantExitCode
ModuleNotFoundError: No module named 'isoquant_lib.utils'
```

`run_pipeline.py` is executed by absolute path, so `sys.path[0]` is `isoquant_tests/github/` — the repo root is **not** on `sys.path`. `import isoquant_lib` therefore resolves to a stale pip-installed copy in `~/.local/lib/python3.10/site-packages/isoquant_lib` (package `isoquant` 3.13.0a0) that predates the `isoquant_lib/utils/` subpackage. `isoquant.py` and the `misc/*.py` QA scripts are unaffected (`isoquant.py` sits at the repo root; the QA scripts don't import `isoquant_lib`).

## Fix

Prepend the repo root (two levels up from the script) to `sys.path` before importing `isoquant_lib`, so the checkout always wins over any installed copy.

Verified: running `run_pipeline.py` by absolute path from a neutral cwd now imports `isoquant_lib` from the checkout instead of `~/.local`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)