### PR TITLE
redirect CI temp dir to /abga to avoid full-root disk failures

### DIFF
--- a/isoquant_tests/github/run_barcode_test.py
+++ b/isoquant_tests/github/run_barcode_test.py
@@ -27,6 +27,18 @@ from traceback import print_exc
 import yaml
 
 
+# CI hosts fill the root filesystem (which holds /tmp); redirect all temp files
+# (Python tempfile, sqlite/gffutils gene-db build) to a roomy filesystem so runs
+# do not die with "database or disk is full". Override via ISOQUANT_CI_TMPDIR.
+_ci_tmpdir = os.environ.get("ISOQUANT_CI_TMPDIR", "/abga/work/andreyp/ci_isoquant/_temp")
+try:
+    os.makedirs(_ci_tmpdir, exist_ok=True)
+    for _tmp_var in ("TMPDIR", "TMP", "TEMP", "SQLITE_TMPDIR"):
+        os.environ[_tmp_var] = _ci_tmpdir
+except OSError:
+    pass
+
+
 # Run types
 RT_VOID = "void"           # Just run detect_barcodes, no quality check
 RT_SINGLE = "single"       # Single barcode per read (10x, curio, stereo)

--- a/isoquant_tests/github/run_pipeline.py
+++ b/isoquant_tests/github/run_pipeline.py
@@ -27,6 +27,18 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(os.path.realpath
 from isoquant_lib.utils.error_codes import IsoQuantExitCode
 
 
+# CI hosts fill the root filesystem (which holds /tmp); redirect all temp files
+# (Python tempfile, sqlite/gffutils gene-db build) to a roomy filesystem so runs
+# do not die with "database or disk is full". Override via ISOQUANT_CI_TMPDIR.
+_ci_tmpdir = os.environ.get("ISOQUANT_CI_TMPDIR", "/abga/work/andreyp/ci_isoquant/_temp")
+try:
+    os.makedirs(_ci_tmpdir, exist_ok=True)
+    for _tmp_var in ("TMPDIR", "TMP", "TEMP", "SQLITE_TMPDIR"):
+        os.environ[_tmp_var] = _ci_tmpdir
+except OSError:
+    pass
+
+
 _quote = {"'": "|'", "|": "||", "\n": "|n", "\r": "|r", '[': '|[', ']': '|]'}
 
 


### PR DESCRIPTION
## Problem

CI runs fail with:

```
sqlite3.OperationalError: database or disk is full
```

during IsoQuant's gffutils gene-DB build (e.g. run 29778076826, "Human ONT R10 simulated polyA 2"). The self-hosted runner's root filesystem (which holds `/tmp`) is 100% full, and sqlite/Python `tempfile` write their scratch there, so the gene-DB creation runs out of space even though the output/annotation filesystem (`/abga`, 1.8 TB free) has room.

## Fix

Both CI launchers (`run_pipeline.py`, `run_barcode_test.py`) now point `TMPDIR`/`TMP`/`TEMP`/`SQLITE_TMPDIR` at a roomy filesystem before spawning IsoQuant, so all temp files (Python tempfile, sqlite/gffutils build) land there instead of the full root. The subprocesses inherit the environment, so this covers the IsoQuant run, QA scripts, and the performance-counter path.

Default is `/abga/work/andreyp/ci_isoquant/_temp` (already present on the runner host); override per-host with `ISOQUANT_CI_TMPDIR`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)