### PR TITLE
Fix SQANTI-like structural categories for novel transcript models

### DIFF
--- a/docs/formats.md
+++ b/docs/formats.md
@@ -301,6 +301,11 @@ where `###` is the unique number (not necessarily consecutive), `XXX` is the chr
 * nic - novel in catalog, new transcript that contains only annotated introns;
 * nnic - novel not in catalog, new transcript that contains unannotated introns.
 
+Note that this type is derived from the intron chain alone. Transcripts discovered in regions
+with no annotated genes have no annotated introns to match and are thus always labelled `nnic`,
+as are novel mono-exonic transcripts. Accordingly, such transcripts are reported as `intergenic`
+in `*.novel_vs_known.SQANTI-like.tsv`.
+
 Each exon also has a unique ID stored in `exon_id` attribute.
 
 In addition, each transcript contains `canonical` property if `--check_canonical` is set.

--- a/isoquant_lib/assignment/isoform_assignment.py
+++ b/isoquant_lib/assignment/isoform_assignment.py
@@ -366,11 +366,13 @@ nnic_event_types = {
     MatchEventSubtype.exon_gain_novel, MatchEventSubtype.exon_skipping_novel,
     MatchEventSubtype.exon_detach_novel, MatchEventSubtype.exon_merge_novel,
     MatchEventSubtype.terminal_exon_shift_novel,
-    MatchEventSubtype.alternative_structure_novel, MatchEventSubtype.intron_alternation_novel,
-    MatchEventSubtype.alternative_polya_site_left, MatchEventSubtype.alternative_polya_site_right,
-    MatchEventSubtype.alternative_tss_right, MatchEventSubtype.alternative_tss_left
+    MatchEventSubtype.alternative_structure_novel, MatchEventSubtype.intron_alternation_novel
 }
 
+# NNIC means a novel splice site, so purely terminal events belong here and not
+# in the NNIC set: an alternative polyA / TSS site on a known intron chain is NIC.
+# A novel splice site elsewhere in the same transcript still wins, since
+# get_inconsistency_classification() checks the NNIC set first.
 nic_event_types = {
     MatchEventSubtype.unspliced_intron_retention, MatchEventSubtype.intron_retention,
     MatchEventSubtype.alt_left_site_known, MatchEventSubtype.alt_right_site_known,
@@ -382,7 +384,9 @@ nic_event_types = {
     MatchEventSubtype.intron_alternation_known, MatchEventSubtype.major_exon_elongation_left,
     MatchEventSubtype.major_exon_elongation_right, MatchEventSubtype.incomplete_intron_retention_left,
     MatchEventSubtype.incomplete_intron_retention_right, MatchEventSubtype.internal_polya_right,
-    MatchEventSubtype.internal_polya_left
+    MatchEventSubtype.internal_polya_left,
+    MatchEventSubtype.alternative_polya_site_left, MatchEventSubtype.alternative_polya_site_right,
+    MatchEventSubtype.alternative_tss_right, MatchEventSubtype.alternative_tss_left
 }
 
 nonintronic_events = {

--- a/isoquant_lib/model_construction/model_construction.py
+++ b/isoquant_lib/model_construction/model_construction.py
@@ -5,11 +5,14 @@
 # See file LICENSE for details.
 ############################################################################
 
+import copy
 import logging
 from collections import defaultdict
 
 from isoquant_lib.common import junctions_from_blocks
 from isoquant_lib.assignment.assignment_io import ReadAssignmentType
+from isoquant_lib.assignment.long_read_assigner import LongReadAssigner
+from isoquant_lib.assignment.long_read_profiles import CombinedProfileConstructor
 from isoquant_lib.gene_info import TranscriptModelType
 from isoquant_lib.assignment.isoform_assignment import (
     match_subtype_to_str_with_additional_info,
@@ -56,9 +59,15 @@ class GraphBasedModelConstructor:
         self.args = ctx.args
         self.string_pools = ctx.string_pools
         self.id_distributor = ctx.id_distributor
-        self.assigner = ctx.assigner
-        self.profile_constructor = ctx.profile_constructor
         self.transcript2transcript = []
+        # Comparison of finished models with the annotation (--sqanti_output).
+        # A model is not a read: its splice sites either coincide with the
+        # annotated ones or are genuinely novel, so this comparison runs with
+        # delta = 0. With args.delta a model built on an intron a few bases off
+        # an annotated one was reported as full_splice_match while its own ID
+        # said .nnic (issue #265).
+        self.model_comparison_assigner, self.model_comparison_profile_constructor = \
+            self._make_model_comparators()
 
         # Construction stages, each operating on the shared ctx / ctx.store.
         # Stage 1: full-length isoforms from intron-graph paths.
@@ -73,6 +82,18 @@ class GraphBasedModelConstructor:
         self.read_assigner = ConstructionReadAssigner(ctx)
         # Stage 4c: final honest per-read assignment + counting + read_info.
         self.model_read_counter = ModelReadCounter(ctx, transcript_counter, gene_counter)
+
+    def _make_model_comparators(self):
+        """Delta-0 assigner + profile constructor used by compare_models_with_known.
+
+        Returns (None, None) unless SQANTI-like output is requested, since this is
+        the only consumer."""
+        if not self.args.sqanti_output:
+            return None, None
+        exact_args = copy.copy(self.args)
+        exact_args.delta = 0
+        return (LongReadAssigner(self.gene_info, exact_args, self.string_pools),
+                CombinedProfileConstructor(self.gene_info, exact_args))
 
     @property
     def transcript_model_storage(self):
@@ -153,8 +174,9 @@ class GraphBasedModelConstructor:
             else:
                 polya_info = PolyAInfo(model.exon_blocks[-1][1], -1, -1, -1)
 
-            combined_profile = self.profile_constructor.construct_profiles(model.exon_blocks, polya_info, [])
-            assignment = self.assigner.assign_to_isoform(model.transcript_id, combined_profile)
+            combined_profile = self.model_comparison_profile_constructor.construct_profiles(model.exon_blocks,
+                                                                                            polya_info, [])
+            assignment = self.model_comparison_assigner.assign_to_isoform(model.transcript_id, combined_profile)
             if assignment is None:
                 continue
 


### PR DESCRIPTION
Fixes #265, where `structural_category` in `*.novel_vs_known.SQANTI-like.tsv` disagreed with the `.nic` / `.nnic` suffix of the transcript ID.

- Model-to-reference comparison now runs with `delta = 0`. A model is not a read: its splice sites either coincide with the annotated ones or are genuinely novel. Previously a model built on an intron a few bases off an annotated one was reported as `full_splice_match` while its ID said `.nnic`.
- `alternative_polya_site_left/right` and `alternative_tss_left/right` moved from the NNIC to the NIC event set. NNIC means a novel splice site, so an alternative polyA / TSS site on a known intron chain is NIC. A novel splice site elsewhere in the transcript still wins, since `get_inconsistency_classification()` checks the NNIC set first.
- Documented that the `nic` / `nnic` suffix is derived from the intron chain alone, so transcripts in unannotated regions and novel mono-exonic ones are always `nnic` and correspondingly `intergenic`.

Only `MatchClassification` changes: all four moved events were already in `nonintronic_events`, so `all_major_events` and `intronic_major_events` are unchanged, and assignment types, counting strategies and model construction gates are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
