### PR TITLE
remove self-hosted runner host names from docs

### DIFF
--- a/.claude/BARCODE2BARCODE_READ_INFO.md
+++ b/.claude/BARCODE2BARCODE_READ_INFO.md
@@ -92,7 +92,7 @@ format the user is moving away from — not recommended.
 - Unit: extend `isoquant_tests/test_umi_filtering.py` — assert the extra round writes
   a column survivor-ID file and that `write_read_info_in_parallel` produces a
   header + one line per survivor with the 18-column `read_info` layout.
-- End-to-end (SC data on dx3/dx4): run a `visium_hd` sample with
+- End-to-end (SC data on a self-hosted runner): run a `visium_hd` sample with
   `--barcode2barcode file.tsv:0:1,2` **without** `--large_output allinfo`; confirm
   `…UMI_filtered.barcode_barcode_col0.ED4.read_info.tsv.gz` (and col1) exist,
   are non-empty, share the main read_info header, and that line counts match the

--- a/.claude/TESTING_SYSTEM.md
+++ b/.claude/TESTING_SYSTEM.md
@@ -385,9 +385,8 @@ All barcode tests check for commits in last 7 days before running (skip if no ch
 
 ### Self-Hosted Runners
 
-Tests run on servers with label `isoquant`:
-- `dx3` - dx3-523-28534.ad.helsinki.fi
-- `dx4` - Available for SSH access
+Tests run on the lab's self-hosted runners, registered with the label `isoquant`.
+Ask a maintainer for the host names and SSH access.
 
 Data and configs are shared via `/abga/work/andreyp/ci_isoquant/`
 
@@ -556,7 +555,7 @@ See `.claude/BARCODE_CALLING.md` for detailed documentation of universal calling
 ### Single Test
 
 ```bash
-# On dx3 or dx4 server
+# On a self-hosted runner
 cd /path/to/IsoQuant2
 export PATH=$PATH:/abga/work/andreyp/ci_isoquant/bin/
 
@@ -584,7 +583,7 @@ python3 tests/github/run_pipeline.py \
 
 ```bash
 # From another machine
-ssh dx3  # or ssh dx4
+ssh <runner-host>
 cd /home/andreyp/IsoQuant2
 # Run tests as above
 ```


### PR DESCRIPTION
Replaces the CI runner FQDN and `dx3`/`dx4` aliases in `.claude/TESTING_SYSTEM.md` and `.claude/BARCODE2BARCODE_READ_INFO.md` with neutral placeholders.

No history rewrite: the string remains in `c93de1ed` and in forks, but is gone from every current checkout and future release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)